### PR TITLE
Fix error in region decode when using rawKVClient APIs

### DIFF
--- a/src/main/java/org/tikv/PDClient.java
+++ b/src/main/java/org/tikv/PDClient.java
@@ -95,6 +95,21 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDStub>
   }
 
   @Override
+  public TiRegion getRegionByRawKey(BackOffer backOffer, ByteString key) {
+    Supplier<GetRegionRequest> request =
+        () -> GetRegionRequest.newBuilder().setHeader(header).setRegionKey(key).build();
+    PDErrorHandler<GetRegionResponse> handler =
+        new PDErrorHandler<>(r -> r.getHeader().hasError() ? r.getHeader().getError() : null, this);
+    GetRegionResponse resp = callWithRetry(backOffer, PDGrpc.METHOD_GET_REGION, request, handler);
+    return new TiRegion(
+        resp.getRegion(),
+        resp.getLeader(),
+        conf.getIsolationLevel(),
+        conf.getCommandPriority(),
+        true);
+  }
+
+  @Override
   public Future<TiRegion> getRegionByKeyAsync(BackOffer backOffer, ByteString key) {
     FutureObserver<TiRegion, GetRegionResponse> responseObserver =
         new FutureObserver<>(

--- a/src/main/java/org/tikv/ReadOnlyPDClient.java
+++ b/src/main/java/org/tikv/ReadOnlyPDClient.java
@@ -39,6 +39,8 @@ public interface ReadOnlyPDClient {
    */
   TiRegion getRegionByKey(BackOffer backOffer, ByteString key);
 
+  TiRegion getRegionByRawKey(BackOffer backOffer, ByteString key);
+
   Future<TiRegion> getRegionByKeyAsync(BackOffer backOffer, ByteString key);
 
   /**

--- a/src/test/java/org/tikv/RawKVClientTest.java
+++ b/src/test/java/org/tikv/RawKVClientTest.java
@@ -12,7 +12,7 @@ import org.tikv.kvproto.Kvrpcpb;
 import org.tikv.util.FastByteComparisons;
 
 public class RawKVClientTest {
-  private static final String RAW_PREFIX = "raw_";
+  private static final String RAW_PREFIX = "raw_\\u0001_";
   private static final int KEY_POOL_SIZE = 1000000;
   private static final int TEST_CASES = 10000;
   private static final int WORKER_CNT = 100;


### PR DESCRIPTION
When using raw APIs, regions should not be decoded as it was when using Txn APIs.

@huachaohuang PTAL.