### PR TITLE
Fix LockResolverTest

### DIFF
--- a/src/test/java/org/tikv/txn/LockResolverTest.java
+++ b/src/test/java/org/tikv/txn/LockResolverTest.java
@@ -205,7 +205,7 @@ public class LockResolverTest {
               resp -> resp.hasRegionError() ? resp.getRegionError() : null);
 
       CommitResponse resp =
-          client.lockResolverClient.callWithRetry(
+          client.callWithRetry(
               backOffer, TikvGrpc.METHOD_KV_COMMIT, factory, handler);
 
       if (resp.hasRegionError()) {


### PR DESCRIPTION
Fixes a bug in test, which may cause unlimited retrying when `StoreNotMatch` error occurs. 