### PR TITLE
Fix gradle build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ bazel-*
 # ignore gradle
 .gradle
 build/
+out/
 
 # Cache of project
 .gradletasknamecache

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ sourceSets {
     main {
         proto {
             srcDir {'proto'}
-			include {'**/*.proto'}
+            include {'**/*.proto'}
         }
         java {
             // include self written and generated code

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'java'
 apply plugin: 'maven'
+apply plugin: 'idea'
 apply plugin: "com.google.protobuf"
 
 group = 'org.tikv'
@@ -11,6 +12,14 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'
+}
+
+idea {
+    module {
+        // Marks the already(!) added srcDir as "generated"
+        generatedSourceDirs += file('target/generated-sources/protobuf/java')
+        generatedSourceDirs += file('target/generated-sources/protobuf/grpc-java')
+    }
 }
 
 buildscript {
@@ -25,16 +34,18 @@ buildscript {
 sourceSets {
     main {
         proto {
-            srcDir 'src/main/proto'
-			include '**/*.proto'
+            srcDir {'proto'}
+			include {'**/*.proto'}
         }
         java {
             // include self written and generated code
-            srcDirs 'src/main/java', 'target/generated-sources/main/java' , 'target/generated-sources/main/grpc-java'
+            srcDirs 'src/main/java', 'target/generated-sources/protobuf/java' , 'target/generated-sources/protobuf/grpc-java'
         }
     }
 	test {
-		java {}
+		java {
+			srcDirs 'src/test/java', 'target/generated-sources/protobuf/java' , 'target/generated-sources/protobuf/grpc-java'
+		}
 	}
     // remove the test configuration - at least in your example you don't have a special test proto file
 }
@@ -64,7 +75,7 @@ protobuf {
         // all() returns the collection of all protoc tasks
         all().each { task ->
 			task.plugins {
-				grpc {
+	 			grpc {
 					outputSubDir = 'grpc-java'
 				}
 			}
@@ -84,7 +95,7 @@ clean {
 }
 
 repositories {
-     maven { url "http://repo.maven.apache.org/maven2" }
+    maven { url "http://repo.maven.apache.org/maven2" }
 }
 
 dependencies {
@@ -127,20 +138,16 @@ task updateProtoModule(type: Exec) {
     }
 }
 
-compileJava << {
-	println 'Compiling'
-}
-
 task copyResources(type: Copy) {
 	includeEmptyDirs = false
 	copy {
-		from "./scripts/kvproto/include/"
+		from "./kvproto/include/"
 	    include "**/gogoproto/**"
-		into "src/main/proto"
+		into "proto"
 	}
 	copy {
-		from "./scripts/kvproto/proto/", "./scripts/raft-rs/proto/", "./scripts/tipb/proto"
-		into "src/main/proto"
+		from "./kvproto/proto/", "./raft-rs/proto/", "./tipb/proto"
+		into "proto"
 	}
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Wed Feb 27 14:56:43 CST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip

--- a/src/main/java/org/tikv/common/operation/KVErrorHandler.java
+++ b/src/main/java/org/tikv/common/operation/KVErrorHandler.java
@@ -131,7 +131,7 @@ public class KVErrorHandler<RespT> implements ErrorHandler<RespT> {
         backOffer.doBackOff(
             BackOffFunction.BackOffFuncType.BoStoreNotMatch, new GrpcException(error.toString()));
         return true;
-      } else if (error.hasStaleEpoch()) {
+      } else if (error.hasEpochNotMatch()) {
         // this error is reported from raftstore:
         // region has outdated version，please try later.
         logger.warn(String.format("Stale Epoch encountered for region [%s]", ctxRegion));

--- a/src/test/java/org/tikv/common/KVMockServer.java
+++ b/src/test/java/org/tikv/common/KVMockServer.java
@@ -36,7 +36,7 @@ import org.tikv.kvproto.Errorpb;
 import org.tikv.kvproto.Errorpb.Error;
 import org.tikv.kvproto.Errorpb.NotLeader;
 import org.tikv.kvproto.Errorpb.ServerIsBusy;
-import org.tikv.kvproto.Errorpb.StaleEpoch;
+import org.tikv.kvproto.Errorpb.EpochNotMatch;
 import org.tikv.kvproto.Kvrpcpb;
 import org.tikv.kvproto.Kvrpcpb.Context;
 import org.tikv.kvproto.TikvGrpc;
@@ -154,7 +154,7 @@ public class KVMockServer extends TikvGrpc.TikvImplBase {
     } else if (errorCode == KEY_NOT_IN_REGION) {
       errBuilder.setKeyNotInRegion(Errorpb.KeyNotInRegion.getDefaultInstance());
     } else if (errorCode == STALE_EPOCH) {
-      errBuilder.setStaleEpoch(Errorpb.StaleEpoch.getDefaultInstance());
+      errBuilder.setEpochNotMatch(Errorpb.EpochNotMatch.getDefaultInstance());
     } else if (errorCode == STALE_COMMAND) {
       errBuilder.setStaleCommand(Errorpb.StaleCommand.getDefaultInstance());
     } else if (errorCode == SERVER_IS_BUSY) {
@@ -318,7 +318,7 @@ public class KVMockServer extends TikvGrpc.TikvImplBase {
         Integer errorCode = errorMap.remove(keyRange.getStart());
         if (errorCode != null) {
           if (STALE_EPOCH == errorCode) {
-            errBuilder.setStaleEpoch(StaleEpoch.getDefaultInstance());
+            errBuilder.setEpochNotMatch(EpochNotMatch.getDefaultInstance());
           } else if (NOT_LEADER == errorCode) {
             errBuilder.setNotLeader(NotLeader.getDefaultInstance());
           } else {


### PR DESCRIPTION
Current gradle build fails because kvproto changed the package name `StaleEpoch` to `EpochNotMatch`. This PR updates gradle build and applies its new name in kvproto. It also separates `build.gradle` changes from #48 