### PR TITLE
Fix ScanIterator may fail when an error encounters

### DIFF
--- a/src/main/java/org/tikv/common/operation/iterator/RawScanIterator.java
+++ b/src/main/java/org/tikv/common/operation/iterator/RawScanIterator.java
@@ -38,23 +38,22 @@ public class RawScanIterator extends ScanIterator {
   }
 
   TiRegion loadCurrentRegionToCache() throws Exception {
-    TiRegion region;
-    try (RegionStoreClient client = builder.build(startKey)) {
-      region = client.getRegion();
-      BackOffer backOffer = ConcreteBackOffer.newScannerNextMaxBackOff();
-      if (limit <= 0) {
-        currentCache = null;
-      } else {
-        while (true) {
+    BackOffer backOffer = ConcreteBackOffer.newScannerNextMaxBackOff();
+    while (true) {
+      try (RegionStoreClient client = builder.build(startKey)) {
+        TiRegion region = client.getRegion();
+        if (limit <= 0) {
+          currentCache = null;
+        } else {
           try {
             currentCache = client.rawScan(backOffer, startKey, limit);
-            break;
           } catch (final TiKVException e) {
             backOffer.doBackOff(BackOffFunction.BackOffFuncType.BoRegionMiss, e);
+            continue;
           }
         }
+        return region;
       }
-      return region;
     }
   }
 

--- a/src/main/java/org/tikv/common/operation/iterator/ScanIterator.java
+++ b/src/main/java/org/tikv/common/operation/iterator/ScanIterator.java
@@ -71,10 +71,8 @@ public abstract class ScanIterator implements Iterator<Kvrpcpb.KvPair> {
       TiRegion region = loadCurrentRegionToCache();
       ByteString curRegionEndKey = region.getEndKey();
       // currentCache is null means no keys found, whereas currentCache is empty means no values
-      // found
-      // the difference lies in whether to continue scanning, because chances are that the same key
-      // is
-      // split in another region because of pending entries, region split, e.t.c.
+      // found. The difference lies in whether to continue scanning, because chances are that
+      // an empty region exists due to deletion, region split, e.t.c.
       // See https://github.com/pingcap/tispark/issues/393 for details
       if (currentCache == null) {
         return true;
@@ -119,22 +117,18 @@ public abstract class ScanIterator implements Iterator<Kvrpcpb.KvPair> {
     if (isCacheDrained()) {
       return null;
     }
-    if (index < currentCache.size()) {
-      --limit;
-      return currentCache.get(index++);
-    }
-    return null;
+    --limit;
+    return currentCache.get(index++);
   }
 
   @Override
   public Kvrpcpb.KvPair next() {
-    Kvrpcpb.KvPair kv = getCurrent();
-    if (kv == null) {
-      // cache drained
+    Kvrpcpb.KvPair kv;
+    // continue when cache is empty but not null
+    for (kv = getCurrent(); currentCache != null && kv == null; kv = getCurrent()) {
       if (cacheLoadFails()) {
         return null;
       }
-      return getCurrent();
     }
     return kv;
   }


### PR DESCRIPTION
When ScanIterator gets an Error from TiKV indicating region info needs to be refreshed, e.g., region epoch is not match, we should retry with a new client to prevent unrecoverable failure.