### PR TITLE
[bugfix][issue-66] Add javax.annotation.version 1.3.2 to pom.xml to e…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,11 +26,17 @@
         <scala.binary.version>2.11</scala.binary.version>
         <scala.version>2.11</scala.version>
         <scalatest.version>3.0.4</scalatest.version>
+        <javax.annotation.version>1.3.2</javax.annotation.version>
         <gpg.skip>true</gpg.skip>
         <javadoc.skip>true</javadoc.skip>
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>${javax.annotation.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>


### PR DESCRIPTION
# Relate to issues-66
Add javax.annotation 1.3.2 to the maven dependency to enable `mvn clean install -DskipTests` compile without errors