### PR TITLE
Reform java client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,10 +12,10 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <protobuf.version>3.1.0</protobuf.version>
+        <protobuf.version>3.5.1</protobuf.version>
         <log4j.version>1.2.17</log4j.version>
         <slf4j.version>1.7.16</slf4j.version>
-        <grpc.version>1.17.0</grpc.version>
+        <grpc.version>1.24.0</grpc.version>
         <powermock.version>1.6.6</powermock.version>
         <jackson.version>2.10.0</jackson.version>
         <trove4j.version>3.0.1</trove4j.version>
@@ -28,9 +28,28 @@
 
     <dependencies>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-            <version>${log4j.version}</version>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>provided</scope>
         </dependency>
         <!-- grpc dependencies -->
         <dependency>
@@ -154,7 +173,7 @@
             <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
-                <version>0.5.0</version>
+                <version>0.6.1</version>
                 <configuration>
                     <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
                     <protoSourceRoot>${proto.folder}</protoSourceRoot>
@@ -162,7 +181,7 @@
                         <param>**/*.proto</param>
                     </includes>
                     <pluginId>grpc-java</pluginId>
-                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.4.0:exe:${os.detected.classifier}</pluginArtifact>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
                 </configuration>
                 <executions>
                     <execution>

--- a/scripts/proto.sh
+++ b/scripts/proto.sh
@@ -14,11 +14,15 @@
 #   limitations under the License.
 #
 
-kvproto_hash=a4759dfe3753ce136d252578340bb2b33633ccfa
+CURRENT_DIR=`pwd`
+TIKV_CLIENT_HOME="$(cd "`dirname "$0"`"/..; pwd)"
+cd $TIKV_CLIENT_HOME
 
-raft_rs_hash=14f007b443935aef51cb161c5b368b54fc8ed176
+kvproto_hash=2cf9a243b8d589f345de1dbaa9eeffec6afbdc06
 
-tipb_hash=c0b8f1a8c8395c319049600dc0efd278f1e26a0d
+raft_rs_hash=b9891b673573fad77ebcf9bbe0969cf945841926
+
+tipb_hash=c4d518eb1d60c21f05b028b36729e64610346dac
 
 if [ -d "kvproto" ]; then
 	cd kvproto; git fetch -p; git checkout ${kvproto_hash}; cd ..
@@ -37,3 +41,5 @@ if [ -d "tipb" ]; then
 else
 	git clone https://github.com/pingcap/tipb; cd tipb; git checkout ${tipb_hash}; cd ..
 fi
+
+cd $CURRENT_DIR

--- a/src/main/java/org/tikv/common/AbstractGRPCClient.java
+++ b/src/main/java/org/tikv/common/AbstractGRPCClient.java
@@ -23,7 +23,8 @@ import io.grpc.stub.AbstractStub;
 import io.grpc.stub.ClientCalls;
 import io.grpc.stub.StreamObserver;
 import java.util.function.Supplier;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.tikv.common.operation.ErrorHandler;
 import org.tikv.common.policy.RetryMaxMs.Builder;
 import org.tikv.common.policy.RetryPolicy;
@@ -34,16 +35,29 @@ import org.tikv.common.util.ChannelFactory;
 public abstract class AbstractGRPCClient<
         BlockingStubT extends AbstractStub<BlockingStubT>, StubT extends AbstractStub<StubT>>
     implements AutoCloseable {
-  protected final Logger logger = Logger.getLogger(this.getClass());
-  protected final TiConfiguration conf;
+  protected final Logger logger = LoggerFactory.getLogger(this.getClass());
   protected final ChannelFactory channelFactory;
+  protected TiConfiguration conf;
+  protected BlockingStubT blockingStub;
+  protected StubT asyncStub;
 
   protected AbstractGRPCClient(TiConfiguration conf, ChannelFactory channelFactory) {
     this.conf = conf;
     this.channelFactory = channelFactory;
   }
 
-  protected TiConfiguration getConf() {
+  protected AbstractGRPCClient(
+      TiConfiguration conf,
+      ChannelFactory channelFactory,
+      BlockingStubT blockingStub,
+      StubT asyncStub) {
+    this.conf = conf;
+    this.channelFactory = channelFactory;
+    this.blockingStub = blockingStub;
+    this.asyncStub = asyncStub;
+  }
+
+  public TiConfiguration getConf() {
     return conf;
   }
 

--- a/src/main/java/org/tikv/common/StoreVersion.java
+++ b/src/main/java/org/tikv/common/StoreVersion.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.tikv.common;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class StoreVersion {
+
+  private static final int SCALE = 10000;
+  private final Logger logger = LoggerFactory.getLogger(this.getClass());
+  private int v0 = 9999;
+  private int v1 = 9999;
+  private int v2 = 9999;
+
+  private StoreVersion(String version) {
+    try {
+      // tiflash version starts with `v`
+      if (version.startsWith("v")) {
+        version = version.substring(1);
+      }
+      String[] parts = version.split("[.-]");
+      if (parts.length > 0) {
+        v0 = Integer.parseInt(parts[0]);
+      }
+      if (parts.length > 1) {
+        v1 = Integer.parseInt(parts[1]);
+      }
+      if (parts.length > 2) {
+        v2 = Integer.parseInt(parts[2]);
+      }
+    } catch (Exception e) {
+      logger.warn("invalid store version: " + version, e);
+    }
+  }
+
+  public static int compareTo(String v0, String v1) {
+    return new StoreVersion(v0).toIntVersion() - new StoreVersion(v1).toIntVersion();
+  }
+
+  private int toIntVersion() {
+    return v0 * SCALE * SCALE + v1 * SCALE + v2;
+  }
+
+  private boolean greatThan(StoreVersion other) {
+    return toIntVersion() > other.toIntVersion();
+  }
+}

--- a/src/main/java/org/tikv/common/TiSession.java
+++ b/src/main/java/org/tikv/common/TiSession.java
@@ -20,6 +20,7 @@ import org.tikv.common.region.RegionManager;
 import org.tikv.common.region.RegionStoreClient.RegionStoreClientBuilder;
 import org.tikv.common.util.ChannelFactory;
 import org.tikv.raw.RawKVClient;
+import org.tikv.txn.KVClient;
 
 /**
  * TiSession is the holder for PD Client, Store pdClient and PD Cache All sessions share common
@@ -51,6 +52,19 @@ public class TiSession implements AutoCloseable {
     RegionStoreClientBuilder builder =
         new RegionStoreClientBuilder(conf, channelFactory, regionMgr, pdClient);
     return new RawKVClient(conf, builder);
+  }
+
+  public KVClient createTxnKVClient() {
+    // Create new Region Manager avoiding thread contentions
+    RegionManager regionMgr = new RegionManager(pdClient);
+    RegionStoreClientBuilder builder =
+        new RegionStoreClientBuilder(conf, channelFactory, regionMgr, pdClient);
+    return new KVClient(conf, builder);
+  }
+
+  @VisibleForTesting
+  public RegionManager getRegionManager() {
+    return new RegionManager(pdClient);
   }
 
   @VisibleForTesting

--- a/src/main/java/org/tikv/common/TiSession.java
+++ b/src/main/java/org/tikv/common/TiSession.java
@@ -49,7 +49,7 @@ public class TiSession implements AutoCloseable {
     // Create new Region Manager avoiding thread contentions
     RegionManager regionMgr = new RegionManager(pdClient);
     RegionStoreClientBuilder builder =
-        new RegionStoreClientBuilder(conf, channelFactory, regionMgr);
+        new RegionStoreClientBuilder(conf, channelFactory, regionMgr, pdClient);
     return new RawKVClient(conf, builder);
   }
 

--- a/src/main/java/org/tikv/common/Version.java
+++ b/src/main/java/org/tikv/common/Version.java
@@ -1,4 +1,5 @@
 /*
+ *
  * Copyright 2020 PingCAP, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,20 +12,17 @@
  * distributed under the License is distributed on an "AS IS" BASIS,
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
-package org.tikv.common.util;
+package org.tikv.common;
 
-import org.tikv.common.meta.TiTimestamp;
+public class Version {
+  public static final String RESOLVE_LOCK_V2 = "2.0.0";
 
-public final class TsoUtils {
-  public static boolean isExpired(long lockTS, long ttl) {
-    // Because the UNIX time in milliseconds is in long style and will
-    // not exceed to become the negative number, so the comparison is correct
-    return untilExpired(lockTS, ttl) <= 0;
-  }
+  public static final String RESOLVE_LOCK_V3 = "3.0.5";
 
-  public static long untilExpired(long lockTS, long ttl) {
-    return TiTimestamp.extractPhysical(lockTS) + ttl - System.currentTimeMillis();
-  }
+  public static final String RESOLVE_LOCK_V4 = "4.0.0";
+
+  public static final String BATCH_WRITE = "3.0.14";
 }

--- a/src/main/java/org/tikv/common/codec/KeyUtils.java
+++ b/src/main/java/org/tikv/common/codec/KeyUtils.java
@@ -17,6 +17,7 @@ package org.tikv.common.codec;
 
 import com.google.common.primitives.UnsignedBytes;
 import com.google.protobuf.ByteString;
+import com.google.protobuf.TextFormat;
 import org.tikv.kvproto.Coprocessor;
 
 public class KeyUtils {
@@ -40,10 +41,31 @@ public class KeyUtils {
   }
 
   public static String formatBytes(Coprocessor.KeyRange keyRange) {
-    return "[[" + formatBytes(keyRange.getStart()) + "], [" + formatBytes(keyRange.getEnd()) + "])";
+    return "([" + formatBytes(keyRange.getStart()) + "], [" + formatBytes(keyRange.getEnd()) + "])";
+  }
+
+  public static String formatBytesUTF8(byte[] bytes) {
+    if (bytes == null) return "null";
+    return TextFormat.escapeBytes(bytes);
+  }
+
+  public static String formatBytesUTF8(ByteString bytes) {
+    if (bytes == null) return "null";
+    return formatBytesUTF8(bytes.toByteArray());
+  }
+
+  public static String formatBytesUTF8(Coprocessor.KeyRange keyRange) {
+    return "(["
+        + formatBytesUTF8(keyRange.getStart())
+        + "], ["
+        + formatBytesUTF8(keyRange.getEnd())
+        + "])";
   }
 
   public static boolean hasPrefix(ByteString str, ByteString prefix) {
+    if (prefix.size() > str.size()) {
+      return false;
+    }
     for (int i = 0; i < prefix.size(); i++) {
       if (str.byteAt(i) != prefix.byteAt(i)) {
         return false;

--- a/src/main/java/org/tikv/common/meta/TiTimestamp.java
+++ b/src/main/java/org/tikv/common/meta/TiTimestamp.java
@@ -16,6 +16,7 @@
 package org.tikv.common.meta;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /** TiTimestamp is the timestamp returned by timestamp oracle inside placement driver */
 public class TiTimestamp implements Serializable {
@@ -29,6 +30,10 @@ public class TiTimestamp implements Serializable {
     this.logical = l;
   }
 
+  public static long extractPhysical(long ts) {
+    return ts >> PHYSICAL_SHIFT_BITS;
+  }
+
   public long getVersion() {
     return (physical << PHYSICAL_SHIFT_BITS) + logical;
   }
@@ -39,5 +44,30 @@ public class TiTimestamp implements Serializable {
 
   public long getLogical() {
     return this.logical;
+  }
+
+  public TiTimestamp getPrevious() {
+    return new TiTimestamp(physical, logical - 1);
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (other == this) {
+      return true;
+    }
+    if (!(other instanceof TiTimestamp)) {
+      return false;
+    }
+    return this.getVersion() == ((TiTimestamp) other).getVersion();
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getVersion());
+  }
+
+  @Override
+  public String toString() {
+    return "TiTimestamp(" + getVersion() + ")";
   }
 }

--- a/src/main/java/org/tikv/common/operation/PDErrorHandler.java
+++ b/src/main/java/org/tikv/common/operation/PDErrorHandler.java
@@ -20,7 +20,8 @@ package org.tikv.common.operation;
 import static org.tikv.common.pd.PDError.buildFromPdpbError;
 
 import java.util.function.Function;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.tikv.common.PDClient;
 import org.tikv.common.exception.GrpcException;
 import org.tikv.common.exception.TiClientInternalException;
@@ -30,15 +31,14 @@ import org.tikv.common.util.BackOffer;
 import org.tikv.kvproto.Pdpb;
 
 public class PDErrorHandler<RespT> implements ErrorHandler<RespT> {
-  private static final Logger logger = Logger.getLogger(PDErrorHandler.class);
-  private final Function<RespT, PDError> getError;
-  private final PDClient client;
-
   public static final Function<Pdpb.GetRegionResponse, PDError> getRegionResponseErrorExtractor =
       r ->
           r.getHeader().hasError()
               ? buildFromPdpbError(r.getHeader().getError())
               : r.getRegion().getId() == 0 ? PDError.RegionPeerNotElected.DEFAULT_INSTANCE : null;
+  private static final Logger logger = LoggerFactory.getLogger(PDErrorHandler.class);
+  private final Function<RespT, PDError> getError;
+  private final PDClient client;
 
   public PDErrorHandler(Function<RespT, PDError> errorExtractor, PDClient client) {
     this.getError = errorExtractor;
@@ -54,12 +54,12 @@ public class PDErrorHandler<RespT> implements ErrorHandler<RespT> {
     if (error != null) {
       switch (error.getErrorType()) {
         case PD_ERROR:
-          client.updateLeader();
           backOffer.doBackOff(
               BackOffFunction.BackOffFuncType.BoPDRPC, new GrpcException(error.toString()));
+          client.updateLeader();
           return true;
         case REGION_PEER_NOT_ELECTED:
-          logger.info(error.getMessage());
+          logger.debug(error.getMessage());
           backOffer.doBackOff(
               BackOffFunction.BackOffFuncType.BoPDRPC, new GrpcException(error.toString()));
           return true;

--- a/src/main/java/org/tikv/common/operation/iterator/ConcreteScanIterator.java
+++ b/src/main/java/org/tikv/common/operation/iterator/ConcreteScanIterator.java
@@ -15,25 +15,61 @@
 
 package org.tikv.common.operation.iterator;
 
+import static java.util.Objects.requireNonNull;
+
 import com.google.protobuf.ByteString;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.tikv.common.TiConfiguration;
+import org.tikv.common.exception.GrpcException;
+import org.tikv.common.exception.KeyException;
+import org.tikv.common.key.Key;
 import org.tikv.common.region.RegionStoreClient;
 import org.tikv.common.region.RegionStoreClient.RegionStoreClientBuilder;
 import org.tikv.common.region.TiRegion;
 import org.tikv.common.util.BackOffer;
 import org.tikv.common.util.ConcreteBackOffer;
+import org.tikv.common.util.Pair;
+import org.tikv.kvproto.Kvrpcpb;
+import org.tikv.kvproto.Metapb;
 
 public class ConcreteScanIterator extends ScanIterator {
   private final long version;
+  private final Logger logger = LoggerFactory.getLogger(ConcreteScanIterator.class);
 
   public ConcreteScanIterator(
-      TiConfiguration conf, RegionStoreClientBuilder builder, ByteString startKey, long version) {
+      TiConfiguration conf,
+      RegionStoreClientBuilder builder,
+      ByteString startKey,
+      long version,
+      int limit) {
     // Passing endKey as ByteString.EMPTY means that endKey is +INF by default,
-    super(conf, builder, startKey, ByteString.EMPTY, Integer.MAX_VALUE);
+    this(conf, builder, startKey, ByteString.EMPTY, version, limit);
+  }
+
+  public ConcreteScanIterator(
+      TiConfiguration conf,
+      RegionStoreClientBuilder builder,
+      ByteString startKey,
+      ByteString endKey,
+      long version) {
+    // Passing endKey as ByteString.EMPTY means that endKey is +INF by default,
+    this(conf, builder, startKey, endKey, version, Integer.MAX_VALUE);
+  }
+
+  private ConcreteScanIterator(
+      TiConfiguration conf,
+      RegionStoreClientBuilder builder,
+      ByteString startKey,
+      ByteString endKey,
+      long version,
+      int limit) {
+    super(conf, builder, startKey, endKey, limit);
     this.version = version;
   }
 
-  TiRegion loadCurrentRegionToCache() throws Exception {
+  @Override
+  TiRegion loadCurrentRegionToCache() throws GrpcException {
     TiRegion region;
     try (RegionStoreClient client = builder.build(startKey)) {
       region = client.getRegion();
@@ -41,5 +77,67 @@ public class ConcreteScanIterator extends ScanIterator {
       currentCache = client.scan(backOffer, startKey, version);
       return region;
     }
+  }
+
+  private ByteString resolveCurrentLock(Kvrpcpb.KvPair current) {
+    logger.warn(String.format("resolve current key error %s", current.getError().toString()));
+    Pair<TiRegion, Metapb.Store> pair =
+        builder.getRegionManager().getRegionStorePairByKey(current.getKey());
+    TiRegion region = pair.first;
+    Metapb.Store store = pair.second;
+    BackOffer backOffer = ConcreteBackOffer.newGetBackOff();
+    try (RegionStoreClient client = builder.build(region, store)) {
+      return client.get(backOffer, current.getKey(), version);
+    } catch (Exception e) {
+      throw new KeyException(current.getError());
+    }
+  }
+
+  @Override
+  public boolean hasNext() {
+    Kvrpcpb.KvPair current;
+    // continue when cache is empty but not null
+    do {
+      current = getCurrent();
+      if (isCacheDrained() && cacheLoadFails()) {
+        endOfScan = true;
+        return false;
+      }
+    } while (currentCache != null && current == null);
+    // for last batch to be processed, we have to check if
+    return !processingLastBatch
+        || current == null
+        || (hasEndKey && Key.toRawKey(current.getKey()).compareTo(endKey) < 0);
+  }
+
+  @Override
+  public Kvrpcpb.KvPair next() {
+    --limit;
+    Kvrpcpb.KvPair current = currentCache.get(index++);
+
+    requireNonNull(current, "current kv pair cannot be null");
+    if (current.hasError()) {
+      ByteString val = resolveCurrentLock(current);
+      current = Kvrpcpb.KvPair.newBuilder().setKey(current.getKey()).setValue(val).build();
+    }
+
+    return current;
+  }
+
+  /**
+   * Cache is drained when - no data extracted - scan limit was not defined - have read the last
+   * index of cache - index not initialized
+   *
+   * @return whether cache is drained
+   */
+  private boolean isCacheDrained() {
+    return currentCache == null || limit <= 0 || index >= currentCache.size() || index == -1;
+  }
+
+  private Kvrpcpb.KvPair getCurrent() {
+    if (isCacheDrained()) {
+      return null;
+    }
+    return currentCache.get(index);
   }
 }

--- a/src/main/java/org/tikv/common/pd/PDError.java
+++ b/src/main/java/org/tikv/common/pd/PDError.java
@@ -24,11 +24,6 @@ public final class PDError {
 
   private final ErrorType errorType;
 
-  public enum ErrorType {
-    PD_ERROR,
-    REGION_PEER_NOT_ELECTED
-  }
-
   private PDError(Pdpb.Error error) {
     this.error = error;
     this.errorType = ErrorType.PD_ERROR;
@@ -66,6 +61,11 @@ public final class PDError {
   @Override
   public String toString() {
     return "\nErrorType: " + errorType + "\nError: " + error;
+  }
+
+  public enum ErrorType {
+    PD_ERROR,
+    REGION_PEER_NOT_ELECTED
   }
 
   public static final class RegionPeerNotElected {

--- a/src/main/java/org/tikv/common/pd/PDUtils.java
+++ b/src/main/java/org/tikv/common/pd/PDUtils.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.tikv.common.pd;
+
+import com.google.common.collect.ImmutableList;
+import java.net.URI;
+import java.util.List;
+
+public class PDUtils {
+  public static URI addrToUrl(String addr) {
+    if (addr.contains("://")) {
+      return URI.create(addr);
+    } else {
+      return URI.create("http://" + addr);
+    }
+  }
+
+  public static List<URI> addrsToUrls(String[] addrs) {
+    ImmutableList.Builder<URI> urlsBuilder = new ImmutableList.Builder<>();
+    for (String addr : addrs) {
+      urlsBuilder.add(addrToUrl(addr));
+    }
+    return urlsBuilder.build();
+  }
+}

--- a/src/main/java/org/tikv/common/region/AbstractRegionStoreClient.java
+++ b/src/main/java/org/tikv/common/region/AbstractRegionStoreClient.java
@@ -1,0 +1,112 @@
+/*
+ *
+ * Copyright 2019 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.tikv.common.region;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import io.grpc.ManagedChannel;
+import org.tikv.common.AbstractGRPCClient;
+import org.tikv.common.TiConfiguration;
+import org.tikv.common.exception.GrpcException;
+import org.tikv.common.util.ChannelFactory;
+import org.tikv.kvproto.Metapb;
+import org.tikv.kvproto.TikvGrpc;
+
+public abstract class AbstractRegionStoreClient
+    extends AbstractGRPCClient<TikvGrpc.TikvBlockingStub, TikvGrpc.TikvStub>
+    implements RegionErrorReceiver {
+
+  protected final RegionManager regionManager;
+  protected TiRegion region;
+
+  protected AbstractRegionStoreClient(
+      TiConfiguration conf,
+      TiRegion region,
+      ChannelFactory channelFactory,
+      TikvGrpc.TikvBlockingStub blockingStub,
+      TikvGrpc.TikvStub asyncStub,
+      RegionManager regionManager) {
+    super(conf, channelFactory, blockingStub, asyncStub);
+    checkNotNull(region, "Region is empty");
+    checkNotNull(region.getLeader(), "Leader Peer is null");
+    checkArgument(region.getLeader() != null, "Leader Peer is null");
+    this.region = region;
+    this.regionManager = regionManager;
+  }
+
+  public TiRegion getRegion() {
+    return region;
+  }
+
+  @Override
+  protected TikvGrpc.TikvBlockingStub getBlockingStub() {
+    return blockingStub.withDeadlineAfter(getConf().getTimeout(), getConf().getTimeoutUnit());
+  }
+
+  @Override
+  protected TikvGrpc.TikvStub getAsyncStub() {
+    return asyncStub.withDeadlineAfter(getConf().getTimeout(), getConf().getTimeoutUnit());
+  }
+
+  @Override
+  public void close() throws GrpcException {}
+
+  /**
+   * onNotLeader deals with NotLeaderError and returns whether re-splitting key range is needed
+   *
+   * @param newStore the new store presented by NotLeader Error
+   * @return false when re-split is needed.
+   */
+  @Override
+  public boolean onNotLeader(Metapb.Store newStore) {
+    if (logger.isDebugEnabled()) {
+      logger.debug(region + ", new leader = " + newStore.getId());
+    }
+    TiRegion cachedRegion = regionManager.getRegionByKey(region.getStartKey());
+    // When switch leader fails or the region changed its key range,
+    // it would be necessary to re-split task's key range for new region.
+    if (!region.getStartKey().equals(cachedRegion.getStartKey())
+        || !region.getEndKey().equals(cachedRegion.getEndKey())) {
+      return false;
+    }
+    region = cachedRegion;
+    String addressStr = regionManager.getStoreById(region.getLeader().getStoreId()).getAddress();
+    ManagedChannel channel = channelFactory.getChannel(addressStr);
+    blockingStub = TikvGrpc.newBlockingStub(channel);
+    asyncStub = TikvGrpc.newStub(channel);
+    return true;
+  }
+
+  @Override
+  public void onStoreNotMatch(Metapb.Store store) {
+    String addressStr = store.getAddress();
+    ManagedChannel channel = channelFactory.getChannel(addressStr);
+    blockingStub = TikvGrpc.newBlockingStub(channel);
+    asyncStub = TikvGrpc.newStub(channel);
+    if (logger.isDebugEnabled() && region.getLeader().getStoreId() != store.getId()) {
+      logger.debug(
+          "store_not_match may occur? "
+              + region
+              + ", original store = "
+              + store.getId()
+              + " address = "
+              + addressStr);
+    }
+  }
+}

--- a/src/main/java/org/tikv/common/util/BackOffer.java
+++ b/src/main/java/org/tikv/common/util/BackOffer.java
@@ -18,6 +18,37 @@
 package org.tikv.common.util;
 
 public interface BackOffer {
+  // Back off types.
+  int seconds = 1000;
+  int COP_BUILD_TASK_MAX_BACKOFF = 5 * seconds;
+  int TSO_MAX_BACKOFF = 5 * seconds;
+  int SCANNER_NEXT_MAX_BACKOFF = 40 * seconds;
+  int BATCH_GET_MAX_BACKOFF = 40 * seconds;
+  int COP_NEXT_MAX_BACKOFF = 40 * seconds;
+  int GET_MAX_BACKOFF = 40 * seconds;
+  int PREWRITE_MAX_BACKOFF = 20 * seconds;
+  int CLEANUP_MAX_BACKOFF = 20 * seconds;
+  int GC_ONE_REGION_MAX_BACKOFF = 20 * seconds;
+  int GC_RESOLVE_LOCK_MAX_BACKOFF = 100 * seconds;
+  int GC_DELETE_RANGE_MAX_BACKOFF = 100 * seconds;
+  int RAWKV_MAX_BACKOFF = 40 * seconds;
+  int SPLIT_REGION_BACKOFF = 20 * seconds;
+  int BATCH_COMMIT_BACKOFF = 10 * seconds;
+  int PD_INFO_BACKOFF = 5 * seconds;
+
+  /**
+   * doBackOff sleeps a while base on the BackOffType and records the error message. Will stop until
+   * max back off time exceeded and throw an exception to the caller.
+   */
+  void doBackOff(BackOffFunction.BackOffFuncType funcType, Exception err);
+
+  /**
+   * BackoffWithMaxSleep sleeps a while base on the backoffType and records the error message and
+   * never sleep more than maxSleepMs for each sleep.
+   */
+  void doBackOffWithMaxSleep(
+      BackOffFunction.BackOffFuncType funcType, long maxSleepMs, Exception err);
+
   // Back off strategies
   enum BackOffStrategy {
     // NoJitter makes the backoff sequence strict exponential.
@@ -29,25 +60,4 @@ public interface BackOffer {
     // DecorrJitter increases the maximum jitter based on the last random value.
     DecorrJitter
   }
-
-  // Back off types.
-  int copBuildTaskMaxBackoff = 5000;
-  int tsoMaxBackoff = 5000;
-  int scannerNextMaxBackoff = 40000;
-  int batchGetMaxBackoff = 40000;
-  int copNextMaxBackoff = 40000;
-  int getMaxBackoff = 40000;
-  int prewriteMaxBackoff = 20000;
-  int cleanupMaxBackoff = 20000;
-  int GcOneRegionMaxBackoff = 20000;
-  int GcResolveLockMaxBackoff = 100000;
-  int GcDeleteRangeMaxBackoff = 100000;
-  int rawkvMaxBackoff = 40000;
-  int splitRegionBackoff = 20000;
-
-  /**
-   * doBackOff sleeps a while base on the BackOffType and records the error message. Will stop until
-   * max back off time exceeded and throw an exception to the caller.
-   */
-  void doBackOff(BackOffFunction.BackOffFuncType funcTypes, Exception err);
 }

--- a/src/main/java/org/tikv/common/util/ConcreteBackOffer.java
+++ b/src/main/java/org/tikv/common/util/ConcreteBackOffer.java
@@ -22,47 +22,16 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.tikv.common.exception.GrpcException;
 
 public class ConcreteBackOffer implements BackOffer {
+  private static final Logger logger = LoggerFactory.getLogger(ConcreteBackOffer.class);
   private final int maxSleep;
-  private int totalSleep;
   private final Map<BackOffFunction.BackOffFuncType, BackOffFunction> backOffFunctionMap;
   private final List<Exception> errors;
-  private static final Logger logger = Logger.getLogger(ConcreteBackOffer.class);
-
-  public static ConcreteBackOffer newCustomBackOff(int maxSleep) {
-    return new ConcreteBackOffer(maxSleep);
-  }
-
-  public static ConcreteBackOffer newScannerNextMaxBackOff() {
-    return new ConcreteBackOffer(scannerNextMaxBackoff);
-  }
-
-  public static ConcreteBackOffer newBatchGetMaxBackOff() {
-    return new ConcreteBackOffer(batchGetMaxBackoff);
-  }
-
-  public static ConcreteBackOffer newCopNextMaxBackOff() {
-    return new ConcreteBackOffer(copNextMaxBackoff);
-  }
-
-  public static ConcreteBackOffer newGetBackOff() {
-    return new ConcreteBackOffer(getMaxBackoff);
-  }
-
-  public static ConcreteBackOffer newRawKVBackOff() {
-    return new ConcreteBackOffer(rawkvMaxBackoff);
-  }
-
-  public static ConcreteBackOffer newTsoBackOff() {
-    return new ConcreteBackOffer(tsoMaxBackoff);
-  }
-
-  public static ConcreteBackOffer create(BackOffer source) {
-    return new ConcreteBackOffer(((ConcreteBackOffer) source));
-  }
+  private int totalSleep;
 
   private ConcreteBackOffer(int maxSleep) {
     Preconditions.checkArgument(maxSleep >= 0, "Max sleep time cannot be less than 0.");
@@ -78,6 +47,38 @@ public class ConcreteBackOffer implements BackOffer {
     this.backOffFunctionMap = source.backOffFunctionMap;
   }
 
+  public static ConcreteBackOffer newCustomBackOff(int maxSleep) {
+    return new ConcreteBackOffer(maxSleep);
+  }
+
+  public static ConcreteBackOffer newScannerNextMaxBackOff() {
+    return new ConcreteBackOffer(SCANNER_NEXT_MAX_BACKOFF);
+  }
+
+  public static ConcreteBackOffer newBatchGetMaxBackOff() {
+    return new ConcreteBackOffer(BATCH_GET_MAX_BACKOFF);
+  }
+
+  public static ConcreteBackOffer newCopNextMaxBackOff() {
+    return new ConcreteBackOffer(COP_NEXT_MAX_BACKOFF);
+  }
+
+  public static ConcreteBackOffer newGetBackOff() {
+    return new ConcreteBackOffer(GET_MAX_BACKOFF);
+  }
+
+  public static ConcreteBackOffer newRawKVBackOff() {
+    return new ConcreteBackOffer(RAWKV_MAX_BACKOFF);
+  }
+
+  public static ConcreteBackOffer newTsoBackOff() {
+    return new ConcreteBackOffer(TSO_MAX_BACKOFF);
+  }
+
+  public static ConcreteBackOffer create(BackOffer source) {
+    return new ConcreteBackOffer(((ConcreteBackOffer) source));
+  }
+
   /**
    * Creates a back off func which implements exponential back off with optional jitters according
    * to different back off strategies. See http://www.awsarchitectureblog.com/2015/03/backoff.html
@@ -86,7 +87,6 @@ public class ConcreteBackOffer implements BackOffer {
     BackOffFunction backOffFunction = null;
     switch (funcType) {
       case BoUpdateLeader:
-        // fix: reference from go client
         backOffFunction = BackOffFunction.create(1, 10, BackOffStrategy.NoJitter);
         break;
       case BoTxnLockFast:
@@ -96,23 +96,19 @@ public class ConcreteBackOffer implements BackOffer {
         backOffFunction = BackOffFunction.create(2000, 10000, BackOffStrategy.EqualJitter);
         break;
       case BoRegionMiss:
-        // fix: reference from go client
-        // change base time to 2ms, because it may recover soon.
-        backOffFunction = BackOffFunction.create(2, 500, BackOffStrategy.NoJitter);
+        backOffFunction = BackOffFunction.create(100, 500, BackOffStrategy.NoJitter);
         break;
       case BoTxnLock:
         backOffFunction = BackOffFunction.create(200, 3000, BackOffStrategy.EqualJitter);
         break;
       case BoPDRPC:
-        //
         backOffFunction = BackOffFunction.create(500, 3000, BackOffStrategy.EqualJitter);
         break;
       case BoTiKVRPC:
-        // fix: reference from go client
         backOffFunction = BackOffFunction.create(100, 2000, BackOffStrategy.EqualJitter);
         break;
-      case BoStoreNotMatch:
-        backOffFunction = BackOffFunction.create(100, 3000, BackOffStrategy.EqualJitter);
+      case BoTxnNotFound:
+        backOffFunction = BackOffFunction.create(2, 500, BackOffStrategy.NoJitter);
         break;
     }
     return backOffFunction;
@@ -120,11 +116,17 @@ public class ConcreteBackOffer implements BackOffer {
 
   @Override
   public void doBackOff(BackOffFunction.BackOffFuncType funcType, Exception err) {
+    doBackOffWithMaxSleep(funcType, -1, err);
+  }
+
+  @Override
+  public void doBackOffWithMaxSleep(
+      BackOffFunction.BackOffFuncType funcType, long maxSleepMs, Exception err) {
     BackOffFunction backOffFunction =
         backOffFunctionMap.computeIfAbsent(funcType, this::createBackOffFunc);
 
     // Back off will be done here
-    totalSleep += backOffFunction.doBackOff();
+    totalSleep += backOffFunction.doBackOff(maxSleepMs);
     logger.debug(
         String.format(
             "%s, retry later(totalSleep %dms, maxSleep %dms)",
@@ -133,7 +135,7 @@ public class ConcreteBackOffer implements BackOffer {
     if (maxSleep > 0 && totalSleep >= maxSleep) {
       StringBuilder errMsg =
           new StringBuilder(
-              String.format("backoffer.maxSleep %dms is exceeded, errors:", maxSleep));
+              String.format("BackOffer.maxSleep %dms is exceeded, errors:", maxSleep));
       for (int i = 0; i < errors.size(); i++) {
         Exception curErr = errors.get(i);
         // Print only last 3 errors for non-DEBUG log levels.

--- a/src/main/java/org/tikv/raw/RawKVClient.java
+++ b/src/main/java/org/tikv/raw/RawKVClient.java
@@ -30,7 +30,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.tikv.common.TiConfiguration;
 import org.tikv.common.exception.GrpcException;
 import org.tikv.common.exception.TiKVException;
@@ -47,7 +48,7 @@ public class RawKVClient implements AutoCloseable {
   private final RegionStoreClientBuilder clientBuilder;
   private final TiConfiguration conf;
   private final ExecutorCompletionService<Object> completionService;
-  private static final Logger logger = Logger.getLogger(RawKVClient.class);
+  private static final Logger logger = LoggerFactory.getLogger(RawKVClient.class);
 
   private static final int MAX_RETRY_LIMIT = 3;
   // https://www.github.com/pingcap/tidb/blob/master/store/tikv/rawkv.go
@@ -55,7 +56,8 @@ public class RawKVClient implements AutoCloseable {
   private static final int RAW_BATCH_PUT_SIZE = 16 * 1024;
   private static final int RAW_BATCH_PAIR_COUNT = 512;
 
-  private static final TiKVException ERR_RETRY_LIMIT_EXCEEDED = new GrpcException("retry is exhausted. retry exceeds " + MAX_RETRY_LIMIT + "attempts");
+  private static final TiKVException ERR_RETRY_LIMIT_EXCEEDED =
+      new GrpcException("retry is exhausted. retry exceeds " + MAX_RETRY_LIMIT + "attempts");
   private static final TiKVException ERR_MAX_SCAN_LIMIT_EXCEEDED =
       new TiKVException("limit should be less than MAX_RAW_SCAN_LIMIT");
 
@@ -291,7 +293,7 @@ public class RawKVClient implements AutoCloseable {
     }
     try {
       for (int i = 0; i < batches.size(); i++) {
-        completionService.take().get(BackOffer.rawkvMaxBackoff, TimeUnit.SECONDS);
+        completionService.take().get(BackOffer.RAWKV_MAX_BACKOFF, TimeUnit.SECONDS);
       }
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();

--- a/src/main/java/org/tikv/txn/AbstractLockResolverClient.java
+++ b/src/main/java/org/tikv/txn/AbstractLockResolverClient.java
@@ -1,0 +1,123 @@
+/*
+ *
+ * Copyright 2020 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.tikv.txn;
+
+import java.util.List;
+import org.tikv.common.PDClient;
+import org.tikv.common.StoreVersion;
+import org.tikv.common.TiConfiguration;
+import org.tikv.common.Version;
+import org.tikv.common.exception.KeyException;
+import org.tikv.common.region.RegionManager;
+import org.tikv.common.region.RegionStoreClient;
+import org.tikv.common.region.TiRegion;
+import org.tikv.common.util.BackOffer;
+import org.tikv.common.util.ChannelFactory;
+import org.tikv.kvproto.Kvrpcpb;
+import org.tikv.kvproto.Metapb;
+import org.tikv.kvproto.TikvGrpc;
+
+public interface AbstractLockResolverClient {
+  /** ResolvedCacheSize is max number of cached txn status. */
+  long RESOLVED_TXN_CACHE_SIZE = 2048;
+
+  /** transaction involves keys exceed this threshold can be treated as `big transaction`. */
+  long BIG_TXN_THRESHOLD = 16;
+
+  static Lock extractLockFromKeyErr(Kvrpcpb.KeyError keyError) {
+    if (keyError.hasLocked()) {
+      return new Lock(keyError.getLocked());
+    }
+
+    if (keyError.hasConflict()) {
+      Kvrpcpb.WriteConflict conflict = keyError.getConflict();
+      throw new KeyException(
+          String.format(
+              "scan meet key conflict on primary key %s at commit ts %s",
+              conflict.getPrimary(), conflict.getConflictTs()));
+    }
+
+    if (!keyError.getRetryable().isEmpty()) {
+      throw new KeyException(
+          String.format("tikv restart txn %s", keyError.getRetryableBytes().toStringUtf8()));
+    }
+
+    if (!keyError.getAbort().isEmpty()) {
+      throw new KeyException(
+          String.format("tikv abort txn %s", keyError.getAbortBytes().toStringUtf8()));
+    }
+
+    throw new KeyException(
+        String.format("unexpected key error meets and it is %s", keyError.toString()));
+  }
+
+  static AbstractLockResolverClient getInstance(
+      Metapb.Store store,
+      TiConfiguration conf,
+      TiRegion region,
+      TikvGrpc.TikvBlockingStub blockingStub,
+      TikvGrpc.TikvStub asyncStub,
+      ChannelFactory channelFactory,
+      RegionManager regionManager,
+      PDClient pdClient,
+      RegionStoreClient.RegionStoreClientBuilder clientBuilder) {
+    if (StoreVersion.compareTo(store.getVersion(), Version.RESOLVE_LOCK_V3) < 0) {
+      return new LockResolverClientV2(
+          conf, region, blockingStub, asyncStub, channelFactory, regionManager);
+    } else if (StoreVersion.compareTo(store.getVersion(), Version.RESOLVE_LOCK_V4) < 0) {
+      return new LockResolverClientV3(
+          conf,
+          region,
+          blockingStub,
+          asyncStub,
+          channelFactory,
+          regionManager,
+          pdClient,
+          clientBuilder);
+    } else {
+      return new LockResolverClientV4(
+          conf,
+          region,
+          blockingStub,
+          asyncStub,
+          channelFactory,
+          regionManager,
+          pdClient,
+          clientBuilder);
+    }
+  }
+
+  String getVersion();
+
+  /**
+   * ResolveLocks tries to resolve Locks. The resolving process is in 3 steps: 1) Use the `lockTTL`
+   * to pick up all expired locks. Only locks that are old enough are considered orphan locks and
+   * will be handled later. If all locks are expired then all locks will be resolved so true will be
+   * returned, otherwise caller should sleep a while before retry. 2) For each lock, query the
+   * primary key to get txn(which left the lock)'s commit status. 3) Send `ResolveLock` cmd to the
+   * lock's region to resolve all locks belong to the same transaction.
+   *
+   * @param bo
+   * @param callerStartTS
+   * @param locks
+   * @param forWrite
+   * @return msBeforeTxnExpired: 0 means all locks are resolved
+   */
+  ResolveLockResult resolveLocks(
+      BackOffer bo, long callerStartTS, List<Lock> locks, boolean forWrite);
+}

--- a/src/main/java/org/tikv/txn/BatchKeys.java
+++ b/src/main/java/org/tikv/txn/BatchKeys.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.tikv.txn;
+
+import com.google.protobuf.ByteString;
+import java.util.ArrayList;
+import java.util.List;
+import org.tikv.common.region.TiRegion;
+import org.tikv.kvproto.Metapb;
+
+public class BatchKeys {
+  private final TiRegion region;
+  private final Metapb.Store store;
+  private List<ByteString> keys;
+  private final int sizeInBytes;
+
+  public BatchKeys(
+      TiRegion region, Metapb.Store store, List<ByteString> keysInput, int sizeInBytes) {
+    this.region = region;
+    this.store = store;
+    this.keys = new ArrayList<>();
+    this.keys.addAll(keysInput);
+    this.sizeInBytes = sizeInBytes;
+  }
+
+  public List<ByteString> getKeys() {
+    return keys;
+  }
+
+  public void setKeys(List<ByteString> keys) {
+    this.keys = keys;
+  }
+
+  public TiRegion getRegion() {
+    return region;
+  }
+
+  public Metapb.Store getStore() {
+    return store;
+  }
+
+  public int getSizeInBytes() {
+    return sizeInBytes;
+  }
+
+  public float getSizeInKB() {
+    return ((float) sizeInBytes) / 1024;
+  }
+}

--- a/src/main/java/org/tikv/txn/ClientRPCResult.java
+++ b/src/main/java/org/tikv/txn/ClientRPCResult.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 The TiKV Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.tikv.txn;
+
+public class ClientRPCResult {
+  private boolean success;
+  private boolean retry;
+  private Exception exception;
+
+  public ClientRPCResult(boolean success, boolean retry, Exception exception) {
+    this.success = success;
+    this.retry = retry;
+    this.exception = exception;
+  }
+
+  public boolean isSuccess() {
+    return success;
+  }
+
+  public void setSuccess(boolean success) {
+    this.success = success;
+  }
+
+  public boolean isRetry() {
+    return retry;
+  }
+
+  public void setRetry(boolean retry) {
+    this.retry = retry;
+  }
+
+  public Exception getException() {
+    return exception;
+  }
+
+  public void setException(Exception exception) {
+    this.exception = exception;
+  }
+}

--- a/src/main/java/org/tikv/txn/GroupKeyResult.java
+++ b/src/main/java/org/tikv/txn/GroupKeyResult.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.tikv.txn;
+
+import com.google.protobuf.ByteString;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.tikv.common.region.TiRegion;
+import org.tikv.common.util.Pair;
+import org.tikv.kvproto.Metapb;
+
+public class GroupKeyResult {
+
+  private Map<Pair<TiRegion, Metapb.Store>, List<ByteString>> groupsResult;
+
+  public GroupKeyResult() {
+    this.groupsResult = new HashMap<>();
+  }
+
+  public Map<Pair<TiRegion, Metapb.Store>, List<ByteString>> getGroupsResult() {
+    return groupsResult;
+  }
+
+  public void setGroupsResult(Map<Pair<TiRegion, Metapb.Store>, List<ByteString>> groupsResult) {
+    this.groupsResult = groupsResult;
+  }
+}

--- a/src/main/java/org/tikv/txn/KVClient.java
+++ b/src/main/java/org/tikv/txn/KVClient.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright 2020 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.tikv.txn;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.google.protobuf.ByteString;
+import java.util.*;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.tikv.common.TiConfiguration;
+import org.tikv.common.exception.GrpcException;
+import org.tikv.common.exception.TiKVException;
+import org.tikv.common.operation.iterator.ConcreteScanIterator;
+import org.tikv.common.region.RegionStoreClient;
+import org.tikv.common.region.RegionStoreClient.RegionStoreClientBuilder;
+import org.tikv.common.region.TiRegion;
+import org.tikv.common.util.BackOffFunction;
+import org.tikv.common.util.BackOffer;
+import org.tikv.common.util.ConcreteBackOffer;
+import org.tikv.kvproto.Kvrpcpb;
+
+public class KVClient implements AutoCloseable {
+  private static final Logger logger = LoggerFactory.getLogger(KVClient.class);
+  private static final int BATCH_GET_SIZE = 16 * 1024;
+  private final RegionStoreClientBuilder clientBuilder;
+  private final TiConfiguration conf;
+  private final ExecutorService executorService;
+
+  public KVClient(TiConfiguration conf, RegionStoreClientBuilder clientBuilder) {
+    Objects.requireNonNull(conf, "conf is null");
+    Objects.requireNonNull(clientBuilder, "clientBuilder is null");
+    this.conf = conf;
+    this.clientBuilder = clientBuilder;
+    executorService =
+        Executors.newFixedThreadPool(
+            conf.getKvClientConcurrency(),
+            new ThreadFactoryBuilder().setNameFormat("kvclient-pool-%d").setDaemon(true).build());
+  }
+
+  @Override
+  public void close() {
+    if (executorService != null) {
+      executorService.shutdownNow();
+    }
+  }
+
+  /**
+   * Get a key-value pair from TiKV if key exists
+   *
+   * @param key key
+   * @return a ByteString value if key exists, ByteString.EMPTY if key does not exist
+   */
+  public ByteString get(ByteString key, long version) throws GrpcException {
+    BackOffer backOffer = ConcreteBackOffer.newGetBackOff();
+    while (true) {
+      RegionStoreClient client = clientBuilder.build(key);
+      try {
+        return client.get(backOffer, key, version);
+      } catch (final TiKVException e) {
+        backOffer.doBackOff(BackOffFunction.BackOffFuncType.BoRegionMiss, e);
+      }
+    }
+  }
+
+  /**
+   * Get a set of key-value pair by keys from TiKV
+   *
+   * @param backOffer
+   * @param keys
+   * @param version
+   * @return
+   * @throws GrpcException
+   */
+  public List<Kvrpcpb.KvPair> batchGet(BackOffer backOffer, List<ByteString> keys, long version)
+      throws GrpcException {
+    return doSendBatchGet(backOffer, keys, version);
+  }
+
+  /**
+   * Scan key-value pairs from TiKV in range [startKey, endKey)
+   *
+   * @param startKey start key, inclusive
+   * @param endKey end key, exclusive
+   * @return list of key-value pairs in range
+   */
+  public List<Kvrpcpb.KvPair> scan(ByteString startKey, ByteString endKey, long version)
+      throws GrpcException {
+    Iterator<Kvrpcpb.KvPair> iterator =
+        scanIterator(conf, clientBuilder, startKey, endKey, version);
+    List<Kvrpcpb.KvPair> result = new ArrayList<>();
+    iterator.forEachRemaining(result::add);
+    return result;
+  }
+
+  /**
+   * Scan key-value pairs from TiKV in range [startKey, ♾), maximum to `limit` pairs
+   *
+   * @param startKey start key, inclusive
+   * @param limit limit of kv pairs
+   * @return list of key-value pairs in range
+   */
+  public List<Kvrpcpb.KvPair> scan(ByteString startKey, long version, int limit)
+      throws GrpcException {
+    Iterator<Kvrpcpb.KvPair> iterator = scanIterator(conf, clientBuilder, startKey, version, limit);
+    List<Kvrpcpb.KvPair> result = new ArrayList<>();
+    iterator.forEachRemaining(result::add);
+    return result;
+  }
+
+  public List<Kvrpcpb.KvPair> scan(ByteString startKey, long version) throws GrpcException {
+    return scan(startKey, version, Integer.MAX_VALUE);
+  }
+
+  private List<Kvrpcpb.KvPair> doSendBatchGet(
+      BackOffer backOffer, List<ByteString> keys, long version) {
+    ExecutorCompletionService<List<Kvrpcpb.KvPair>> completionService =
+        new ExecutorCompletionService<>(executorService);
+
+    Map<TiRegion, List<ByteString>> groupKeys = groupKeysByRegion(keys);
+    List<Batch> batches = new ArrayList<>();
+
+    for (Map.Entry<TiRegion, List<ByteString>> entry : groupKeys.entrySet()) {
+      appendBatches(batches, entry.getKey(), entry.getValue(), BATCH_GET_SIZE);
+    }
+
+    for (Batch batch : batches) {
+      BackOffer singleBatchBackOffer = ConcreteBackOffer.create(backOffer);
+      completionService.submit(
+          () -> doSendBatchGetInBatchesWithRetry(singleBatchBackOffer, batch, version));
+    }
+
+    try {
+      List<Kvrpcpb.KvPair> result = new ArrayList<>();
+      for (int i = 0; i < batches.size(); i++) {
+        result.addAll(completionService.take().get());
+      }
+      return result;
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new TiKVException("Current thread interrupted.", e);
+    } catch (ExecutionException e) {
+      throw new TiKVException("Execution exception met.", e);
+    }
+  }
+
+  private List<Kvrpcpb.KvPair> doSendBatchGetInBatchesWithRetry(
+      BackOffer backOffer, Batch batch, long version) {
+    TiRegion oldRegion = batch.region;
+    TiRegion currentRegion =
+        clientBuilder.getRegionManager().getRegionByKey(oldRegion.getStartKey());
+
+    if (oldRegion.equals(currentRegion)) {
+      RegionStoreClient client = clientBuilder.build(batch.region);
+      try {
+        return client.batchGet(backOffer, batch.keys, version);
+      } catch (final TiKVException e) {
+        backOffer.doBackOff(BackOffFunction.BackOffFuncType.BoRegionMiss, e);
+        clientBuilder.getRegionManager().invalidateRegion(batch.region.getId());
+        logger.warn("ReSplitting ranges for BatchGetRequest", e);
+
+        // retry
+        return doSendBatchGetWithRefetchRegion(backOffer, batch, version);
+      }
+    } else {
+      return doSendBatchGetWithRefetchRegion(backOffer, batch, version);
+    }
+  }
+
+  private List<Kvrpcpb.KvPair> doSendBatchGetWithRefetchRegion(
+      BackOffer backOffer, Batch batch, long version) {
+    Map<TiRegion, List<ByteString>> groupKeys = groupKeysByRegion(batch.keys);
+    List<Batch> retryBatches = new ArrayList<>();
+
+    for (Map.Entry<TiRegion, List<ByteString>> entry : groupKeys.entrySet()) {
+      appendBatches(retryBatches, entry.getKey(), entry.getValue(), BATCH_GET_SIZE);
+    }
+
+    ArrayList<Kvrpcpb.KvPair> results = new ArrayList<>();
+    for (Batch retryBatch : retryBatches) {
+      // recursive calls
+      List<Kvrpcpb.KvPair> batchResult =
+          doSendBatchGetInBatchesWithRetry(backOffer, retryBatch, version);
+      results.addAll(batchResult);
+    }
+    return results;
+  }
+
+  /**
+   * Append batch to list and split them according to batch limit
+   *
+   * @param batches a grouped batch
+   * @param region region
+   * @param keys keys
+   * @param batchGetMaxSizeInByte batch max limit
+   */
+  private void appendBatches(
+      List<Batch> batches, TiRegion region, List<ByteString> keys, int batchGetMaxSizeInByte) {
+    int start;
+    int end;
+    if (keys == null) {
+      return;
+    }
+    int len = keys.size();
+    for (start = 0; start < len; start = end) {
+      int size = 0;
+      for (end = start; end < len && size < batchGetMaxSizeInByte; end++) {
+        size += keys.get(end).size();
+      }
+      Batch batch = new Batch(region, keys.subList(start, end));
+      batches.add(batch);
+    }
+  }
+
+  /**
+   * Group by list of keys according to its region
+   *
+   * @param keys keys
+   * @return a mapping of keys and their region
+   */
+  private Map<TiRegion, List<ByteString>> groupKeysByRegion(List<ByteString> keys) {
+    return keys.stream()
+        .collect(Collectors.groupingBy(clientBuilder.getRegionManager()::getRegionByKey));
+  }
+
+  private Iterator<Kvrpcpb.KvPair> scanIterator(
+      TiConfiguration conf,
+      RegionStoreClientBuilder builder,
+      ByteString startKey,
+      ByteString endKey,
+      long version) {
+    return new ConcreteScanIterator(conf, builder, startKey, endKey, version);
+  }
+
+  private Iterator<Kvrpcpb.KvPair> scanIterator(
+      TiConfiguration conf,
+      RegionStoreClientBuilder builder,
+      ByteString startKey,
+      long version,
+      int limit) {
+    return new ConcreteScanIterator(conf, builder, startKey, version, limit);
+  }
+
+  /** A Batch containing the region and a list of keys to send */
+  private static final class Batch {
+    private final TiRegion region;
+    private final List<ByteString> keys;
+
+    Batch(TiRegion region, List<ByteString> keys) {
+      this.region = region;
+      this.keys = keys;
+    }
+  }
+}

--- a/src/main/java/org/tikv/txn/Lock.java
+++ b/src/main/java/org/tikv/txn/Lock.java
@@ -21,17 +21,23 @@ import com.google.protobuf.ByteString;
 import org.tikv.kvproto.Kvrpcpb;
 
 public class Lock {
+  private static final long DEFAULT_LOCK_TTL = 3000;
   private final long txnID;
   private final long ttl;
   private final ByteString key;
   private final ByteString primary;
-  private static final long defaultLockTTL = 3000;
+  private final long txnSize;
+  private final Kvrpcpb.Op lockType;
+  private final long lockForUpdateTs;
 
   public Lock(Kvrpcpb.LockInfo l) {
     txnID = l.getLockVersion();
     key = l.getKey();
     primary = l.getPrimaryLock();
-    ttl = l.getLockTtl() == 0 ? defaultLockTTL : l.getLockTtl();
+    ttl = l.getLockTtl() == 0 ? DEFAULT_LOCK_TTL : l.getLockTtl();
+    txnSize = l.getTxnSize();
+    lockType = l.getLockType();
+    lockForUpdateTs = l.getLockForUpdateTs();
   }
 
   public long getTxnID() {
@@ -48,5 +54,17 @@ public class Lock {
 
   public ByteString getPrimary() {
     return primary;
+  }
+
+  public long getTxnSize() {
+    return txnSize;
+  }
+
+  public Kvrpcpb.Op getLockType() {
+    return lockType;
+  }
+
+  public long getLockForUpdateTs() {
+    return lockForUpdateTs;
   }
 }

--- a/src/main/java/org/tikv/txn/LockResolverClientV3.java
+++ b/src/main/java/org/tikv/txn/LockResolverClientV3.java
@@ -1,0 +1,325 @@
+/*
+ *
+ * Copyright 2020 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.tikv.txn;
+
+import static org.tikv.common.util.BackOffFunction.BackOffFuncType.BoRegionMiss;
+
+import com.google.protobuf.ByteString;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.tikv.common.PDClient;
+import org.tikv.common.TiConfiguration;
+import org.tikv.common.exception.KeyException;
+import org.tikv.common.exception.RegionException;
+import org.tikv.common.exception.TiClientInternalException;
+import org.tikv.common.operation.KVErrorHandler;
+import org.tikv.common.region.AbstractRegionStoreClient;
+import org.tikv.common.region.RegionManager;
+import org.tikv.common.region.RegionStoreClient;
+import org.tikv.common.region.TiRegion;
+import org.tikv.common.region.TiRegion.RegionVerID;
+import org.tikv.common.util.BackOffer;
+import org.tikv.common.util.ChannelFactory;
+import org.tikv.common.util.TsoUtils;
+import org.tikv.kvproto.Kvrpcpb;
+import org.tikv.kvproto.Kvrpcpb.CleanupRequest;
+import org.tikv.kvproto.Kvrpcpb.CleanupResponse;
+import org.tikv.kvproto.TikvGrpc;
+import org.tikv.kvproto.TikvGrpc.TikvBlockingStub;
+import org.tikv.kvproto.TikvGrpc.TikvStub;
+
+/** Since v3.0.5 TiDB ignores the ttl on secondary lock and will use the ttl on primary key. */
+public class LockResolverClientV3 extends AbstractRegionStoreClient
+    implements AbstractLockResolverClient {
+  private static final Logger logger = LoggerFactory.getLogger(LockResolverClientV3.class);
+
+  private final ReadWriteLock readWriteLock;
+
+  /**
+   * Note: Because the internal of long is same as unsigned_long and Txn id are never changed. Be
+   * careful to compare between two tso the `resolved` mapping is as {@code Map<TxnId, TxnStatus>}
+   * TxnStatus represents a txn's final status. It should be Commit or Rollback. if TxnStatus > 0,
+   * means the commit ts, otherwise abort
+   */
+  private final Map<Long, TxnStatus> resolved;
+
+  /** the list is chain of txn for O(1) lru cache */
+  private final Queue<Long> recentResolved;
+
+  private final PDClient pdClient;
+
+  private final RegionStoreClient.RegionStoreClientBuilder clientBuilder;
+
+  public LockResolverClientV3(
+      TiConfiguration conf,
+      TiRegion region,
+      TikvBlockingStub blockingStub,
+      TikvStub asyncStub,
+      ChannelFactory channelFactory,
+      RegionManager regionManager,
+      PDClient pdClient,
+      RegionStoreClient.RegionStoreClientBuilder clientBuilder) {
+    super(conf, region, channelFactory, blockingStub, asyncStub, regionManager);
+    resolved = new HashMap<>();
+    recentResolved = new LinkedList<>();
+    readWriteLock = new ReentrantReadWriteLock();
+    this.pdClient = pdClient;
+    this.clientBuilder = clientBuilder;
+  }
+
+  @Override
+  public String getVersion() {
+    return "V3";
+  }
+
+  @Override
+  public ResolveLockResult resolveLocks(
+      BackOffer bo, long callerStartTS, List<Lock> locks, boolean forWrite) {
+    TxnExpireTime msBeforeTxnExpired = new TxnExpireTime();
+
+    if (locks.isEmpty()) {
+      return new ResolveLockResult(msBeforeTxnExpired.value());
+    }
+
+    List<Lock> expiredLocks = new ArrayList<>();
+    for (Lock lock : locks) {
+      if (TsoUtils.isExpired(lock.getTxnID(), lock.getTtl())) {
+        expiredLocks.add(lock);
+      } else {
+        msBeforeTxnExpired.update(lock.getTtl());
+      }
+    }
+
+    if (expiredLocks.isEmpty()) {
+      return new ResolveLockResult(msBeforeTxnExpired.value());
+    }
+
+    Map<Long, Set<RegionVerID>> cleanTxns = new HashMap<>();
+    for (Lock l : expiredLocks) {
+      TxnStatus status = getTxnStatusFromLock(bo, l);
+
+      if (status.getTtl() == 0) {
+        Set<RegionVerID> cleanRegion =
+            cleanTxns.computeIfAbsent(l.getTxnID(), k -> new HashSet<>());
+
+        resolveLock(bo, l, status, cleanRegion);
+      } else {
+        long msBeforeLockExpired = TsoUtils.untilExpired(l.getTxnID(), status.getTtl());
+        msBeforeTxnExpired.update(msBeforeLockExpired);
+      }
+    }
+
+    return new ResolveLockResult(msBeforeTxnExpired.value());
+  }
+
+  private void resolveLock(
+      BackOffer bo, Lock lock, TxnStatus txnStatus, Set<RegionVerID> cleanRegion) {
+    boolean cleanWholeRegion = lock.getTxnSize() >= BIG_TXN_THRESHOLD;
+
+    while (true) {
+      region = regionManager.getRegionByKey(lock.getKey());
+
+      if (cleanRegion.contains(region.getVerID())) {
+        return;
+      }
+
+      Kvrpcpb.ResolveLockRequest.Builder builder =
+          Kvrpcpb.ResolveLockRequest.newBuilder()
+              .setContext(region.getContext())
+              .setStartVersion(lock.getTxnID());
+
+      if (txnStatus.isCommitted()) {
+        // txn is committed with commitTS txnStatus
+        builder.setCommitVersion(txnStatus.getCommitTS());
+      }
+
+      if (lock.getTxnSize() < BIG_TXN_THRESHOLD) {
+        // Only resolve specified keys when it is a small transaction,
+        // prevent from scanning the whole region in this case.
+        builder.addKeys(lock.getKey());
+      }
+
+      Supplier<Kvrpcpb.ResolveLockRequest> factory = builder::build;
+      KVErrorHandler<Kvrpcpb.ResolveLockResponse> handler =
+          new KVErrorHandler<>(
+              regionManager,
+              this,
+              this,
+              region,
+              resp -> resp.hasRegionError() ? resp.getRegionError() : null,
+              resp -> resp.hasError() ? resp.getError() : null,
+              resolveLockResult -> null,
+              0L,
+              false);
+      Kvrpcpb.ResolveLockResponse resp =
+          callWithRetry(bo, TikvGrpc.getKvResolveLockMethod(), factory, handler);
+
+      if (resp == null) {
+        logger.error("getKvResolveLockMethod failed without a cause");
+        regionManager.onRequestFail(region);
+        bo.doBackOff(
+            BoRegionMiss,
+            new TiClientInternalException("getKvResolveLockMethod failed without a cause"));
+        continue;
+      }
+
+      if (resp.hasRegionError()) {
+        bo.doBackOff(BoRegionMiss, new RegionException(resp.getRegionError()));
+        continue;
+      }
+
+      if (resp.hasError()) {
+        logger.error(
+            String.format("unexpected resolveLock err: %s, lock: %s", resp.getError(), lock));
+        throw new KeyException(resp.getError());
+      }
+
+      if (cleanWholeRegion) {
+        cleanRegion.add(region.getVerID());
+      }
+      return;
+    }
+  }
+
+  private TxnStatus getTxnStatusFromLock(BackOffer bo, Lock lock) {
+    // NOTE: l.TTL = 0 is a special protocol!!!
+    // When the pessimistic txn prewrite meets locks of a txn, it should rollback that txn
+    // **unconditionally**.
+    // In this case, TiKV set the lock TTL = 0, and TiDB use currentTS = 0 to call
+    // getTxnStatus, and getTxnStatus with currentTS = 0 would rollback the transaction.
+    if (lock.getTtl() == 0) {
+      return getTxnStatus(bo, lock.getTxnID(), lock.getPrimary(), 0L);
+    }
+
+    long currentTS = pdClient.getTimestamp(bo).getVersion();
+    return getTxnStatus(bo, lock.getTxnID(), lock.getPrimary(), currentTS);
+  }
+
+  private TxnStatus getTxnStatus(BackOffer bo, Long txnID, ByteString primary, Long currentTS) {
+    TxnStatus status = getResolved(txnID);
+    if (status != null) {
+      return status;
+    }
+
+    Supplier<CleanupRequest> factory =
+        () -> {
+          TiRegion primaryKeyRegion = regionManager.getRegionByKey(primary);
+          return CleanupRequest.newBuilder()
+              .setContext(primaryKeyRegion.getContext())
+              .setKey(primary)
+              .setStartVersion(txnID)
+              .setCurrentTs(currentTS)
+              .build();
+        };
+
+    status = new TxnStatus();
+    while (true) {
+      TiRegion primaryKeyRegion = regionManager.getRegionByKey(primary);
+      // new RegionStoreClient for PrimaryKey
+      RegionStoreClient primaryKeyRegionStoreClient = clientBuilder.build(primary);
+      KVErrorHandler<CleanupResponse> handler =
+          new KVErrorHandler<>(
+              regionManager,
+              primaryKeyRegionStoreClient,
+              primaryKeyRegionStoreClient.lockResolverClient,
+              primaryKeyRegion,
+              resp -> resp.hasRegionError() ? resp.getRegionError() : null,
+              resp -> resp.hasError() ? resp.getError() : null,
+              resolveLockResult -> null,
+              0L,
+              false);
+
+      CleanupResponse resp =
+          primaryKeyRegionStoreClient.callWithRetry(
+              bo, TikvGrpc.getKvCleanupMethod(), factory, handler);
+
+      if (resp == null) {
+        logger.error("getKvCleanupMethod failed without a cause");
+        regionManager.onRequestFail(primaryKeyRegion);
+        bo.doBackOff(
+            BoRegionMiss,
+            new TiClientInternalException("getKvCleanupMethod failed without a cause"));
+        continue;
+      }
+
+      if (resp.hasRegionError()) {
+        bo.doBackOff(BoRegionMiss, new RegionException(resp.getRegionError()));
+        continue;
+      }
+
+      if (resp.hasError()) {
+        Kvrpcpb.KeyError keyError = resp.getError();
+
+        // If the TTL of the primary lock is not outdated, the proto returns a ErrLocked contains
+        // the TTL.
+        if (keyError.hasLocked()) {
+          Kvrpcpb.LockInfo lockInfo = keyError.getLocked();
+          return new TxnStatus(lockInfo.getLockTtl(), 0L);
+        }
+
+        logger.error(String.format("unexpected cleanup err: %s, tid: %d", keyError, txnID));
+        throw new KeyException(keyError);
+      }
+
+      if (resp.getCommitVersion() != 0) {
+        status = new TxnStatus(0L, resp.getCommitVersion());
+      }
+
+      saveResolved(txnID, status);
+      return status;
+    }
+  }
+
+  private void saveResolved(long txnID, TxnStatus status) {
+    try {
+      readWriteLock.writeLock().lock();
+      if (resolved.containsKey(txnID)) {
+        return;
+      }
+
+      resolved.put(txnID, status);
+      recentResolved.add(txnID);
+      if (recentResolved.size() > RESOLVED_TXN_CACHE_SIZE) {
+        Long front = recentResolved.remove();
+        resolved.remove(front);
+      }
+    } finally {
+      readWriteLock.writeLock().unlock();
+    }
+  }
+
+  private TxnStatus getResolved(Long txnID) {
+    try {
+      readWriteLock.readLock().lock();
+      return resolved.get(txnID);
+    } finally {
+      readWriteLock.readLock().unlock();
+    }
+  }
+}

--- a/src/main/java/org/tikv/txn/LockResolverClientV4.java
+++ b/src/main/java/org/tikv/txn/LockResolverClientV4.java
@@ -1,0 +1,451 @@
+/*
+ *
+ * Copyright 2020 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.tikv.txn;
+
+import static org.tikv.common.util.BackOffFunction.BackOffFuncType.BoRegionMiss;
+import static org.tikv.common.util.BackOffFunction.BackOffFuncType.BoTxnNotFound;
+
+import com.google.protobuf.ByteString;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.tikv.common.PDClient;
+import org.tikv.common.TiConfiguration;
+import org.tikv.common.exception.KeyException;
+import org.tikv.common.exception.RegionException;
+import org.tikv.common.exception.TiClientInternalException;
+import org.tikv.common.operation.KVErrorHandler;
+import org.tikv.common.region.AbstractRegionStoreClient;
+import org.tikv.common.region.RegionManager;
+import org.tikv.common.region.RegionStoreClient;
+import org.tikv.common.region.TiRegion;
+import org.tikv.common.region.TiRegion.RegionVerID;
+import org.tikv.common.util.BackOffer;
+import org.tikv.common.util.ChannelFactory;
+import org.tikv.common.util.TsoUtils;
+import org.tikv.kvproto.Kvrpcpb;
+import org.tikv.kvproto.TikvGrpc;
+import org.tikv.kvproto.TikvGrpc.TikvBlockingStub;
+import org.tikv.kvproto.TikvGrpc.TikvStub;
+import org.tikv.txn.exception.TxnNotFoundException;
+import org.tikv.txn.exception.WriteConflictException;
+
+/** Since v4.0.0 TiDB write will not block read (update MinCommitTS). */
+public class LockResolverClientV4 extends AbstractRegionStoreClient
+    implements AbstractLockResolverClient {
+  private static final Logger logger = LoggerFactory.getLogger(LockResolverClientV4.class);
+
+  private final ReadWriteLock readWriteLock;
+
+  /**
+   * Note: Because the internal of long is same as unsigned_long and Txn id are never changed. Be
+   * careful to compare between two tso the `resolved` mapping is as {@code Map<TxnId, TxnStatus>}
+   * TxnStatus represents a txn's final status. It should be Commit or Rollback. if TxnStatus > 0,
+   * means the commit ts, otherwise abort
+   */
+  private final Map<Long, TxnStatus> resolved;
+
+  /** the list is chain of txn for O(1) lru cache */
+  private final Queue<Long> recentResolved;
+
+  private final PDClient pdClient;
+
+  private final RegionStoreClient.RegionStoreClientBuilder clientBuilder;
+
+  public LockResolverClientV4(
+      TiConfiguration conf,
+      TiRegion region,
+      TikvBlockingStub blockingStub,
+      TikvStub asyncStub,
+      ChannelFactory channelFactory,
+      RegionManager regionManager,
+      PDClient pdClient,
+      RegionStoreClient.RegionStoreClientBuilder clientBuilder) {
+    super(conf, region, channelFactory, blockingStub, asyncStub, regionManager);
+    resolved = new HashMap<>();
+    recentResolved = new LinkedList<>();
+    readWriteLock = new ReentrantReadWriteLock();
+    this.pdClient = pdClient;
+    this.clientBuilder = clientBuilder;
+  }
+
+  @Override
+  public String getVersion() {
+    return "V4";
+  }
+
+  @Override
+  public ResolveLockResult resolveLocks(
+      BackOffer bo, long callerStartTS, List<Lock> locks, boolean forWrite) {
+    TxnExpireTime msBeforeTxnExpired = new TxnExpireTime();
+
+    if (locks.isEmpty()) {
+      return new ResolveLockResult(msBeforeTxnExpired.value());
+    }
+
+    Map<Long, Set<RegionVerID>> cleanTxns = new HashMap<>();
+    boolean pushFail = false;
+    List<Long> pushed = new ArrayList<>(locks.size());
+
+    for (Lock l : locks) {
+      TxnStatus status = getTxnStatusFromLock(bo, l, callerStartTS);
+
+      if (status.getTtl() == 0) {
+        Set<RegionVerID> cleanRegion =
+            cleanTxns.computeIfAbsent(l.getTxnID(), k -> new HashSet<>());
+
+        if (l.getLockType() == Kvrpcpb.Op.PessimisticLock) {
+          resolvePessimisticLock(bo, l, cleanRegion);
+        } else {
+          resolveLock(bo, l, status, cleanRegion);
+        }
+
+      } else {
+        long msBeforeLockExpired = TsoUtils.untilExpired(l.getTxnID(), status.getTtl());
+        msBeforeTxnExpired.update(msBeforeLockExpired);
+
+        if (forWrite) {
+          // Write conflict detected!
+          // If it's a optimistic conflict and current txn is earlier than the lock owner,
+          // abort current transaction.
+          // This could avoids the deadlock scene of two large transaction.
+          if (l.getLockType() != Kvrpcpb.Op.PessimisticLock && l.getTxnID() > callerStartTS) {
+            throw new WriteConflictException(
+                callerStartTS, l.getTxnID(), status.getCommitTS(), l.getKey().toByteArray());
+          }
+        } else {
+          if (status.getAction() != Kvrpcpb.Action.MinCommitTSPushed) {
+            pushFail = true;
+          } else {
+            pushed.add(l.getTxnID());
+          }
+        }
+      }
+    }
+
+    if (pushFail) {
+      pushed = new ArrayList<>();
+    }
+
+    return new ResolveLockResult(msBeforeTxnExpired.value(), pushed);
+  }
+
+  private void resolvePessimisticLock(BackOffer bo, Lock lock, Set<RegionVerID> cleanRegion) {
+    while (true) {
+      region = regionManager.getRegionByKey(lock.getKey());
+
+      if (cleanRegion.contains(region.getVerID())) {
+        return;
+      }
+
+      final long forUpdateTS =
+          lock.getLockForUpdateTs() == 0L ? Long.MAX_VALUE : lock.getLockForUpdateTs();
+
+      Supplier<Kvrpcpb.PessimisticRollbackRequest> factory =
+          () ->
+              Kvrpcpb.PessimisticRollbackRequest.newBuilder()
+                  .setContext(region.getContext())
+                  .setStartVersion(lock.getTxnID())
+                  .setForUpdateTs(forUpdateTS)
+                  .addKeys(lock.getKey())
+                  .build();
+
+      KVErrorHandler<Kvrpcpb.PessimisticRollbackResponse> handler =
+          new KVErrorHandler<>(
+              regionManager,
+              this,
+              this,
+              region,
+              resp -> resp.hasRegionError() ? resp.getRegionError() : null,
+              resp -> resp.getErrorsCount() > 0 ? resp.getErrorsList().get(0) : null,
+              resolveLockResult -> null,
+              0L,
+              false);
+      Kvrpcpb.PessimisticRollbackResponse resp =
+          callWithRetry(bo, TikvGrpc.getKVPessimisticRollbackMethod(), factory, handler);
+
+      if (resp == null) {
+        logger.error("getKVPessimisticRollbackMethod failed without a cause");
+        regionManager.onRequestFail(region);
+        bo.doBackOff(
+            BoRegionMiss,
+            new TiClientInternalException("getKVPessimisticRollbackMethod failed without a cause"));
+        continue;
+      }
+
+      if (resp.hasRegionError()) {
+        bo.doBackOff(BoRegionMiss, new RegionException(resp.getRegionError()));
+        continue;
+      }
+
+      if (resp.getErrorsCount() > 0) {
+        logger.error(
+            String.format(
+                "unexpected resolveLock err: %s, lock: %s", resp.getErrorsList().get(0), lock));
+        throw new KeyException(resp.getErrorsList().get(0));
+      }
+    }
+  }
+
+  private TxnStatus getTxnStatusFromLock(BackOffer bo, Lock lock, long callerStartTS) {
+    long currentTS;
+
+    if (lock.getTtl() == 0) {
+      // NOTE: l.TTL = 0 is a special protocol!!!
+      // When the pessimistic txn prewrite meets locks of a txn, it should resolve the lock
+      // **unconditionally**.
+      // In this case, TiKV use lock TTL = 0 to notify TiDB, and TiDB should resolve the lock!
+      // Set currentTS to max uint64 to make the lock expired.
+      currentTS = Long.MAX_VALUE;
+    } else {
+      currentTS = pdClient.getTimestamp(bo).getVersion();
+    }
+
+    boolean rollbackIfNotExist = false;
+    while (true) {
+      try {
+        return getTxnStatus(
+            bo, lock.getTxnID(), lock.getPrimary(), callerStartTS, currentTS, rollbackIfNotExist);
+      } catch (TxnNotFoundException e) {
+        // If the error is something other than txnNotFoundErr, throw the error (network
+        // unavailable, tikv down, backoff timeout etc) to the caller.
+        logger.warn("getTxnStatus error!", e);
+
+        // Handle txnNotFound error.
+        // getTxnStatus() returns it when the secondary locks exist while the primary lock doesn't.
+        // This is likely to happen in the concurrently prewrite when secondary regions
+        // success before the primary region.
+        bo.doBackOff(BoTxnNotFound, e);
+      }
+
+      if (TsoUtils.untilExpired(lock.getTxnID(), lock.getTtl()) <= 0) {
+        logger.warn(
+            String.format(
+                "lock txn not found, lock has expired, CallerStartTs=%d lock str=%s",
+                callerStartTS, lock.toString()));
+        if (lock.getLockType() == Kvrpcpb.Op.PessimisticLock) {
+          return new TxnStatus();
+        }
+        rollbackIfNotExist = true;
+      } else {
+        if (lock.getLockType() == Kvrpcpb.Op.PessimisticLock) {
+          return new TxnStatus(lock.getTtl());
+        }
+      }
+    }
+  }
+
+  /**
+   * getTxnStatus sends the CheckTxnStatus request to the TiKV server. When rollbackIfNotExist is
+   * false, the caller should be careful with the TxnNotFoundException error.
+   */
+  private TxnStatus getTxnStatus(
+      BackOffer bo,
+      Long txnID,
+      ByteString primary,
+      Long callerStartTS,
+      Long currentTS,
+      boolean rollbackIfNotExist) {
+    TxnStatus status = getResolved(txnID);
+    if (status != null) {
+      return status;
+    }
+
+    // CheckTxnStatus may meet the following cases:
+    // 1. LOCK
+    // 1.1 Lock expired -- orphan lock, fail to update TTL, crash recovery etc.
+    // 1.2 Lock TTL -- active transaction holding the lock.
+    // 2. NO LOCK
+    // 2.1 Txn Committed
+    // 2.2 Txn Rollbacked -- rollback itself, rollback by others, GC tomb etc.
+    // 2.3 No lock -- pessimistic lock rollback, concurrence prewrite.
+    Supplier<Kvrpcpb.CheckTxnStatusRequest> factory =
+        () -> {
+          TiRegion primaryKeyRegion = regionManager.getRegionByKey(primary);
+          return Kvrpcpb.CheckTxnStatusRequest.newBuilder()
+              .setContext(primaryKeyRegion.getContext())
+              .setPrimaryKey(primary)
+              .setLockTs(txnID)
+              .setCallerStartTs(callerStartTS)
+              .setCurrentTs(currentTS)
+              .setRollbackIfNotExist(rollbackIfNotExist)
+              .build();
+        };
+
+    while (true) {
+      TiRegion primaryKeyRegion = regionManager.getRegionByKey(primary);
+      // new RegionStoreClient for PrimaryKey
+      RegionStoreClient primaryKeyRegionStoreClient = clientBuilder.build(primary);
+      KVErrorHandler<Kvrpcpb.CheckTxnStatusResponse> handler =
+          new KVErrorHandler<>(
+              regionManager,
+              primaryKeyRegionStoreClient,
+              primaryKeyRegionStoreClient.lockResolverClient,
+              primaryKeyRegion,
+              resp -> resp.hasRegionError() ? resp.getRegionError() : null,
+              resp -> resp.hasError() ? resp.getError() : null,
+              resolveLockResult -> null,
+              callerStartTS,
+              false);
+
+      Kvrpcpb.CheckTxnStatusResponse resp =
+          primaryKeyRegionStoreClient.callWithRetry(
+              bo, TikvGrpc.getKvCheckTxnStatusMethod(), factory, handler);
+
+      if (resp == null) {
+        logger.error("getKvCheckTxnStatusMethod failed without a cause");
+        regionManager.onRequestFail(primaryKeyRegion);
+        bo.doBackOff(
+            BoRegionMiss,
+            new TiClientInternalException("getKvCheckTxnStatusMethod failed without a cause"));
+        continue;
+      }
+
+      if (resp.hasRegionError()) {
+        bo.doBackOff(BoRegionMiss, new RegionException(resp.getRegionError()));
+        continue;
+      }
+
+      if (resp.hasError()) {
+        Kvrpcpb.KeyError keyError = resp.getError();
+
+        if (keyError.hasTxnNotFound()) {
+          throw new TxnNotFoundException();
+        }
+
+        logger.error(String.format("unexpected cleanup err: %s, tid: %d", keyError, txnID));
+        throw new KeyException(keyError);
+      }
+
+      if (resp.getLockTtl() != 0) {
+        status = new TxnStatus(resp.getLockTtl(), 0L, resp.getAction());
+      } else {
+        status = new TxnStatus(0L, resp.getCommitVersion(), resp.getAction());
+        saveResolved(txnID, status);
+      }
+
+      return status;
+    }
+  }
+
+  private void resolveLock(
+      BackOffer bo, Lock lock, TxnStatus txnStatus, Set<RegionVerID> cleanRegion) {
+    boolean cleanWholeRegion = lock.getTxnSize() >= BIG_TXN_THRESHOLD;
+
+    while (true) {
+      region = regionManager.getRegionByKey(lock.getKey());
+
+      if (cleanRegion.contains(region.getVerID())) {
+        return;
+      }
+
+      Kvrpcpb.ResolveLockRequest.Builder builder =
+          Kvrpcpb.ResolveLockRequest.newBuilder()
+              .setContext(region.getContext())
+              .setStartVersion(lock.getTxnID());
+
+      if (txnStatus.isCommitted()) {
+        // txn is committed with commitTS txnStatus
+        builder.setCommitVersion(txnStatus.getCommitTS());
+      }
+
+      if (lock.getTxnSize() < BIG_TXN_THRESHOLD) {
+        // Only resolve specified keys when it is a small transaction,
+        // prevent from scanning the whole region in this case.
+        builder.addKeys(lock.getKey());
+      }
+
+      Supplier<Kvrpcpb.ResolveLockRequest> factory = builder::build;
+      KVErrorHandler<Kvrpcpb.ResolveLockResponse> handler =
+          new KVErrorHandler<>(
+              regionManager,
+              this,
+              this,
+              region,
+              resp -> resp.hasRegionError() ? resp.getRegionError() : null,
+              resp -> resp.hasError() ? resp.getError() : null,
+              resolveLockResult -> null,
+              0L,
+              false);
+      Kvrpcpb.ResolveLockResponse resp =
+          callWithRetry(bo, TikvGrpc.getKvResolveLockMethod(), factory, handler);
+
+      if (resp == null) {
+        logger.error("getKvResolveLockMethod failed without a cause");
+        regionManager.onRequestFail(region);
+        bo.doBackOff(
+            BoRegionMiss,
+            new TiClientInternalException("getKvResolveLockMethod failed without a cause"));
+        continue;
+      }
+
+      if (resp.hasRegionError()) {
+        bo.doBackOff(BoRegionMiss, new RegionException(resp.getRegionError()));
+        continue;
+      }
+
+      if (resp.hasError()) {
+        logger.error(
+            String.format("unexpected resolveLock err: %s, lock: %s", resp.getError(), lock));
+        throw new KeyException(resp.getError());
+      }
+
+      if (cleanWholeRegion) {
+        cleanRegion.add(region.getVerID());
+      }
+      return;
+    }
+  }
+
+  private void saveResolved(long txnID, TxnStatus status) {
+    try {
+      readWriteLock.writeLock().lock();
+      if (resolved.containsKey(txnID)) {
+        return;
+      }
+
+      resolved.put(txnID, status);
+      recentResolved.add(txnID);
+      if (recentResolved.size() > RESOLVED_TXN_CACHE_SIZE) {
+        Long front = recentResolved.remove();
+        resolved.remove(front);
+      }
+    } finally {
+      readWriteLock.writeLock().unlock();
+    }
+  }
+
+  private TxnStatus getResolved(Long txnID) {
+    try {
+      readWriteLock.readLock().lock();
+      return resolved.get(txnID);
+    } finally {
+      readWriteLock.readLock().unlock();
+    }
+  }
+}

--- a/src/main/java/org/tikv/txn/ResolveLockResult.java
+++ b/src/main/java/org/tikv/txn/ResolveLockResult.java
@@ -1,0 +1,44 @@
+/*
+ *
+ * Copyright 2020 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.tikv.txn;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ResolveLockResult {
+  private final long msBeforeTxnExpired;
+  private final List<Long> resolvedLocks;
+
+  public ResolveLockResult(long msBeforeTxnExpired) {
+    this.msBeforeTxnExpired = msBeforeTxnExpired;
+    this.resolvedLocks = new ArrayList<>();
+  }
+
+  public ResolveLockResult(long msBeforeTxnExpired, List<Long> resolvedLocks) {
+    this.msBeforeTxnExpired = msBeforeTxnExpired;
+    this.resolvedLocks = resolvedLocks;
+  }
+
+  public long getMsBeforeTxnExpired() {
+    return msBeforeTxnExpired;
+  }
+
+  public List<Long> getResolvedLocks() {
+    return resolvedLocks;
+  }
+}

--- a/src/main/java/org/tikv/txn/TxnExpireTime.java
+++ b/src/main/java/org/tikv/txn/TxnExpireTime.java
@@ -1,0 +1,55 @@
+/*
+ *
+ * Copyright 2020 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.tikv.txn;
+
+public class TxnExpireTime {
+
+  private boolean initialized = false;
+  private long txnExpire = 0;
+
+  public TxnExpireTime() {}
+
+  public TxnExpireTime(boolean initialized, long txnExpire) {
+    this.initialized = initialized;
+    this.txnExpire = txnExpire;
+  }
+
+  public void update(long lockExpire) {
+    if (lockExpire < 0) {
+      lockExpire = 0;
+    }
+
+    if (!this.initialized) {
+      this.txnExpire = lockExpire;
+      this.initialized = true;
+      return;
+    }
+
+    if (lockExpire < this.txnExpire) {
+      this.txnExpire = lockExpire;
+    }
+  }
+
+  public long value() {
+    if (!this.initialized) {
+      return 0L;
+    } else {
+      return this.txnExpire;
+    }
+  }
+}

--- a/src/main/java/org/tikv/txn/TxnKVClient.java
+++ b/src/main/java/org/tikv/txn/TxnKVClient.java
@@ -1,5 +1,188 @@
+/*
+ * Copyright 2019 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.tikv.txn;
 
-public class TxnKVClient {
-  // TODO: To be done.
+import com.google.common.collect.Lists;
+import com.google.protobuf.ByteString;
+import io.grpc.StatusRuntimeException;
+import java.util.Arrays;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.tikv.common.ReadOnlyPDClient;
+import org.tikv.common.TiConfiguration;
+import org.tikv.common.exception.GrpcException;
+import org.tikv.common.exception.KeyException;
+import org.tikv.common.exception.RegionException;
+import org.tikv.common.exception.TiClientInternalException;
+import org.tikv.common.exception.TiKVException;
+import org.tikv.common.meta.TiTimestamp;
+import org.tikv.common.region.RegionManager;
+import org.tikv.common.region.RegionStoreClient;
+import org.tikv.common.region.TiRegion;
+import org.tikv.common.util.BackOffFunction;
+import org.tikv.common.util.BackOffer;
+import org.tikv.common.util.ConcreteBackOffer;
+import org.tikv.kvproto.Kvrpcpb;
+import org.tikv.kvproto.Metapb;
+
+/** KV client of transaction APIs for GET/PUT/DELETE/SCAN */
+public class TxnKVClient implements AutoCloseable {
+  private static final Logger LOG = LoggerFactory.getLogger(TxnKVClient.class);
+
+  private final RegionStoreClient.RegionStoreClientBuilder clientBuilder;
+  private final TiConfiguration conf;
+  private final RegionManager regionManager;
+  private final ReadOnlyPDClient pdClient;
+
+  public TxnKVClient(
+      TiConfiguration conf,
+      RegionStoreClient.RegionStoreClientBuilder clientBuilder,
+      ReadOnlyPDClient pdClient) {
+    this.conf = conf;
+    this.clientBuilder = clientBuilder;
+    this.regionManager = clientBuilder.getRegionManager();
+    this.pdClient = pdClient;
+  }
+
+  public TiConfiguration getConf() {
+    return conf;
+  }
+
+  public RegionManager getRegionManager() {
+    return regionManager;
+  }
+
+  public TiTimestamp getTimestamp() {
+    BackOffer bo = ConcreteBackOffer.newTsoBackOff();
+    TiTimestamp timestamp = new TiTimestamp(0, 0);
+    try {
+      while (true) {
+        try {
+          timestamp = pdClient.getTimestamp(bo);
+          break;
+        } catch (final TiKVException e) {
+          // retry is exhausted
+          bo.doBackOff(BackOffFunction.BackOffFuncType.BoPDRPC, e);
+        }
+      }
+    } catch (GrpcException e1) {
+      LOG.error("Get tso from pd failed,", e1);
+    }
+    return timestamp;
+  }
+
+  /** when encountered region error,ErrBodyMissing, and other errors */
+  public ClientRPCResult prewrite(
+      BackOffer backOffer,
+      List<Kvrpcpb.Mutation> mutations,
+      ByteString primary,
+      long lockTTL,
+      long startTs,
+      TiRegion tiRegion,
+      Metapb.Store store) {
+    ClientRPCResult result = new ClientRPCResult(true, false, null);
+    // send request
+    RegionStoreClient client = clientBuilder.build(tiRegion, store);
+    try {
+      client.prewrite(backOffer, primary, mutations, startTs, lockTTL);
+    } catch (Exception e) {
+      result.setSuccess(false);
+      // mark retryable, region error, should retry prewrite again
+      result.setRetry(retryableException(e));
+      result.setException(e);
+    }
+    return result;
+  }
+
+  /** TXN Heart Beat: update primary key ttl */
+  public ClientRPCResult txnHeartBeat(
+      BackOffer backOffer,
+      ByteString primaryLock,
+      long startTs,
+      long ttl,
+      TiRegion tiRegion,
+      Metapb.Store store) {
+    ClientRPCResult result = new ClientRPCResult(true, false, null);
+    // send request
+    RegionStoreClient client = clientBuilder.build(tiRegion, store);
+    try {
+      client.txnHeartBeat(backOffer, primaryLock, startTs, ttl);
+    } catch (Exception e) {
+      result.setSuccess(false);
+      // mark retryable, region error, should retry heart beat again
+      result.setRetry(retryableException(e));
+      result.setException(e);
+    }
+    return result;
+  }
+
+  /**
+   * Commit request of 2pc, add backoff logic when encountered region error, ErrBodyMissing, and
+   * other errors
+   *
+   * @param backOffer
+   * @param keys
+   * @param startTs
+   * @param commitTs
+   * @param tiRegion
+   * @return
+   */
+  public ClientRPCResult commit(
+      BackOffer backOffer,
+      ByteString[] keys,
+      long startTs,
+      long commitTs,
+      TiRegion tiRegion,
+      Metapb.Store store) {
+    ClientRPCResult result = new ClientRPCResult(true, false, null);
+    // send request
+    RegionStoreClient client = clientBuilder.build(tiRegion, store);
+    List<ByteString> byteList = Lists.newArrayList();
+    byteList.addAll(Arrays.asList(keys));
+    try {
+      client.commit(backOffer, byteList, startTs, commitTs);
+    } catch (Exception e) {
+      result.setSuccess(false);
+      // mark retryable, region error, should retry prewrite again
+      result.setRetry(retryableException(e));
+      result.setException(e);
+    }
+    return result;
+  }
+
+  // According to TiDB's implementation, when it comes to rpc error
+  // commit status remains undecided.
+  // If we fail to receive response for the request that commits primary key, it will be
+  // undetermined whether this
+  // transaction has been successfully committed.
+  // Under this circumstance,  we can not declare the commit is complete (may lead to data lost),
+  // nor can we throw
+  // an error (may lead to the duplicated key error when upper level restarts the transaction).
+  // Currently the best
+  // solution is to populate this error and let upper layer drop the connection to the corresponding
+  // mysql client.
+  // TODO: check this logic to see are we satisfied?
+  private boolean retryableException(Exception e) {
+    return e instanceof TiClientInternalException
+        || e instanceof KeyException
+        || e instanceof RegionException
+        || e instanceof StatusRuntimeException;
+  }
+
+  @Override
+  public void close() throws Exception {}
 }

--- a/src/main/java/org/tikv/txn/TxnStatus.java
+++ b/src/main/java/org/tikv/txn/TxnStatus.java
@@ -1,0 +1,85 @@
+/*
+ *
+ * Copyright 2020 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.tikv.txn;
+
+import org.tikv.kvproto.Kvrpcpb;
+
+/**
+ * ttl > 0: lock is not resolved
+ *
+ * <p>ttl = 0 && commitTS = 0: lock is deleted
+ *
+ * <p>ttl = 0 && commitTS > 0: lock is committed
+ */
+public class TxnStatus {
+  private long ttl;
+  private long commitTS;
+  private Kvrpcpb.Action action;
+
+  public TxnStatus() {
+    this.ttl = 0L;
+    this.commitTS = 0L;
+    this.action = Kvrpcpb.Action.UNRECOGNIZED;
+  }
+
+  public TxnStatus(long ttl) {
+    this.ttl = ttl;
+    this.commitTS = 0L;
+    this.action = Kvrpcpb.Action.UNRECOGNIZED;
+  }
+
+  public TxnStatus(long ttl, long commitTS) {
+    this.ttl = ttl;
+    this.commitTS = commitTS;
+    this.action = Kvrpcpb.Action.UNRECOGNIZED;
+  }
+
+  public TxnStatus(long ttl, long commitTS, Kvrpcpb.Action action) {
+    this.ttl = ttl;
+    this.commitTS = commitTS;
+    this.action = action;
+  }
+
+  public long getTtl() {
+    return ttl;
+  }
+
+  public void setTtl(long ttl) {
+    this.ttl = ttl;
+  }
+
+  public long getCommitTS() {
+    return commitTS;
+  }
+
+  public void setCommitTS(long commitTS) {
+    this.commitTS = commitTS;
+  }
+
+  public boolean isCommitted() {
+    return ttl == 0 && commitTS > 0;
+  }
+
+  public Kvrpcpb.Action getAction() {
+    return action;
+  }
+
+  public void setAction(Kvrpcpb.Action action) {
+    this.action = action;
+  }
+}

--- a/src/main/java/org/tikv/txn/exception/TxnNotFoundException.java
+++ b/src/main/java/org/tikv/txn/exception/TxnNotFoundException.java
@@ -12,19 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.tikv.txn.exception;
 
-package org.tikv.common.util;
-
-import org.tikv.common.meta.TiTimestamp;
-
-public final class TsoUtils {
-  public static boolean isExpired(long lockTS, long ttl) {
-    // Because the UNIX time in milliseconds is in long style and will
-    // not exceed to become the negative number, so the comparison is correct
-    return untilExpired(lockTS, ttl) <= 0;
-  }
-
-  public static long untilExpired(long lockTS, long ttl) {
-    return TiTimestamp.extractPhysical(lockTS) + ttl - System.currentTimeMillis();
-  }
-}
+public class TxnNotFoundException extends RuntimeException {}

--- a/src/main/java/org/tikv/txn/exception/WriteConflictException.java
+++ b/src/main/java/org/tikv/txn/exception/WriteConflictException.java
@@ -13,18 +13,15 @@
  * limitations under the License.
  */
 
-package org.tikv.common.util;
+package org.tikv.txn.exception;
 
-import org.tikv.common.meta.TiTimestamp;
+import org.tikv.common.codec.KeyUtils;
 
-public final class TsoUtils {
-  public static boolean isExpired(long lockTS, long ttl) {
-    // Because the UNIX time in milliseconds is in long style and will
-    // not exceed to become the negative number, so the comparison is correct
-    return untilExpired(lockTS, ttl) <= 0;
-  }
-
-  public static long untilExpired(long lockTS, long ttl) {
-    return TiTimestamp.extractPhysical(lockTS) + ttl - System.currentTimeMillis();
+public class WriteConflictException extends RuntimeException {
+  public WriteConflictException(long callerStartTS, long txnID, long commitTS, byte[] key) {
+    super(
+        String.format(
+            "callerStartTS=%d txnID=%d commitTS=%d key=%s",
+            callerStartTS, txnID, commitTS, KeyUtils.formatBytes(key)));
   }
 }

--- a/src/test/java/org/tikv/common/KVMockServer.java
+++ b/src/test/java/org/tikv/common/KVMockServer.java
@@ -46,8 +46,8 @@ public class KVMockServer extends TikvGrpc.TikvImplBase {
   private int port;
   private Server server;
   private TiRegion region;
-  private TreeMap<Key, ByteString> dataMap = new TreeMap<>();
-  private Map<ByteString, Integer> errorMap = new HashMap<>();
+  private final TreeMap<Key, ByteString> dataMap = new TreeMap<>();
+  private final Map<ByteString, Integer> errorMap = new HashMap<>();
 
   // for KV error
   public static final int ABORT = 1;
@@ -303,7 +303,7 @@ public class KVMockServer extends TikvGrpc.TikvImplBase {
       verifyContext(requestWrap.getContext());
 
       DAGRequest request = DAGRequest.parseFrom(requestWrap.getData());
-      if (request.getStartTs() == 0) {
+      if (request.getStartTsFallback() == 0) {
         throw new Exception();
       }
 

--- a/src/test/java/org/tikv/common/PDMockServerTest.java
+++ b/src/test/java/org/tikv/common/PDMockServerTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.tikv.common;
+
+import java.io.IOException;
+import org.junit.After;
+import org.junit.Before;
+
+public abstract class PDMockServerTest {
+  protected static final String LOCAL_ADDR = "127.0.0.1";
+  static final long CLUSTER_ID = 1024;
+  protected static TiSession session;
+  protected PDMockServer pdServer;
+
+  @Before
+  public void setUp() throws IOException {
+    setUp(LOCAL_ADDR);
+  }
+
+  void setUp(String addr) throws IOException {
+    pdServer = new PDMockServer();
+    pdServer.start(CLUSTER_ID);
+    pdServer.addGetMemberResp(
+        GrpcUtils.makeGetMembersResponse(
+            pdServer.getClusterId(),
+            GrpcUtils.makeMember(1, "http://" + addr + ":" + pdServer.port),
+            GrpcUtils.makeMember(2, "http://" + addr + ":" + (pdServer.port + 1)),
+            GrpcUtils.makeMember(3, "http://" + addr + ":" + (pdServer.port + 2))));
+    TiConfiguration conf = TiConfiguration.createDefault(addr + ":" + pdServer.port);
+    session = TiSession.create(conf);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    session.close();
+    pdServer.stop();
+  }
+}

--- a/src/test/java/org/tikv/common/RegionManagerTest.java
+++ b/src/test/java/org/tikv/common/RegionManagerTest.java
@@ -19,7 +19,6 @@ import static org.junit.Assert.*;
 
 import com.google.protobuf.ByteString;
 import java.io.IOException;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.tikv.common.region.RegionManager;
@@ -29,33 +28,14 @@ import org.tikv.kvproto.Metapb;
 import org.tikv.kvproto.Metapb.Store;
 import org.tikv.kvproto.Metapb.StoreState;
 
-public class RegionManagerTest {
-  private PDMockServer server;
-  private static final long CLUSTER_ID = 1024;
-  private static final String LOCAL_ADDR = "127.0.0.1";
+public class RegionManagerTest extends PDMockServerTest {
   private RegionManager mgr;
-  private TiSession session;
 
   @Before
-  public void setup() throws IOException {
-    server = new PDMockServer();
-    server.start(CLUSTER_ID);
-    server.addGetMemberResp(
-        GrpcUtils.makeGetMembersResponse(
-            server.getClusterId(),
-            GrpcUtils.makeMember(1, "http://" + LOCAL_ADDR + ":" + server.port),
-            GrpcUtils.makeMember(2, "http://" + LOCAL_ADDR + ":" + (server.port + 1)),
-            GrpcUtils.makeMember(2, "http://" + LOCAL_ADDR + ":" + (server.port + 2))));
-
-    TiConfiguration conf = TiConfiguration.createDefault("127.0.0.1:" + server.port);
-    session = TiSession.create(conf);
-    mgr = new RegionManager(session.getPDClient());
-  }
-
-  @After
-  public void tearDown() {
-    server.stop();
-    session.close();
+  @Override
+  public void setUp() throws IOException {
+    super.setUp();
+    mgr = session.getRegionManager();
   }
 
   @Test
@@ -67,9 +47,9 @@ public class RegionManagerTest {
     int confVer = 1026;
     int ver = 1027;
     long regionId = 233;
-    server.addGetRegionResp(
+    pdServer.addGetRegionResp(
         GrpcUtils.makeGetRegionResponse(
-            server.getClusterId(),
+            pdServer.getClusterId(),
             GrpcUtils.makeRegion(
                 regionId,
                 GrpcUtils.encodeKey(startKey.toByteArray()),
@@ -102,9 +82,9 @@ public class RegionManagerTest {
     int confVer = 1026;
     int ver = 1027;
     long regionId = 233;
-    server.addGetRegionResp(
+    pdServer.addGetRegionResp(
         GrpcUtils.makeGetRegionResponse(
-            server.getClusterId(),
+            pdServer.getClusterId(),
             GrpcUtils.makeRegion(
                 regionId,
                 GrpcUtils.encodeKey(startKey.toByteArray()),
@@ -112,9 +92,9 @@ public class RegionManagerTest {
                 GrpcUtils.makeRegionEpoch(confVer, ver),
                 GrpcUtils.makePeer(storeId, 10),
                 GrpcUtils.makePeer(storeId + 1, 20))));
-    server.addGetStoreResp(
+    pdServer.addGetStoreResp(
         GrpcUtils.makeGetStoreResponse(
-            server.getClusterId(),
+            pdServer.getClusterId(),
             GrpcUtils.makeStore(
                 storeId,
                 testAddress,
@@ -130,9 +110,9 @@ public class RegionManagerTest {
   public void getStoreById() throws Exception {
     long storeId = 234;
     String testAddress = "testAddress";
-    server.addGetStoreResp(
+    pdServer.addGetStoreResp(
         GrpcUtils.makeGetStoreResponse(
-            server.getClusterId(),
+            pdServer.getClusterId(),
             GrpcUtils.makeStore(
                 storeId,
                 testAddress,
@@ -142,9 +122,9 @@ public class RegionManagerTest {
     Store store = mgr.getStoreById(storeId);
     assertEquals(store.getId(), storeId);
 
-    server.addGetStoreResp(
+    pdServer.addGetStoreResp(
         GrpcUtils.makeGetStoreResponse(
-            server.getClusterId(),
+            pdServer.getClusterId(),
             GrpcUtils.makeStore(
                 storeId + 1,
                 testAddress,

--- a/src/test/java/org/tikv/common/RegionManagerTest.java
+++ b/src/test/java/org/tikv/common/RegionManagerTest.java
@@ -127,41 +127,6 @@ public class RegionManagerTest {
   }
 
   @Test
-  public void getRegionById() throws Exception {
-    ByteString startKey = ByteString.copyFrom(new byte[] {1});
-    ByteString endKey = ByteString.copyFrom(new byte[] {10});
-
-    int confVer = 1026;
-    int ver = 1027;
-    long regionId = 233;
-    server.addGetRegionByIDResp(
-        GrpcUtils.makeGetRegionResponse(
-            server.getClusterId(),
-            GrpcUtils.makeRegion(
-                regionId,
-                GrpcUtils.encodeKey(startKey.toByteArray()),
-                GrpcUtils.encodeKey(endKey.toByteArray()),
-                GrpcUtils.makeRegionEpoch(confVer, ver),
-                GrpcUtils.makePeer(1, 10),
-                GrpcUtils.makePeer(2, 20))));
-    TiRegion region = mgr.getRegionById(regionId);
-    assertEquals(region.getId(), regionId);
-
-    TiRegion regionToSearch = mgr.getRegionById(regionId);
-    assertEquals(region, regionToSearch);
-
-    mgr.invalidateRegion(regionId);
-
-    // This will in turn invoke rpc and results in an error
-    // since we set just one rpc response
-    try {
-      mgr.getRegionById(regionId);
-      fail();
-    } catch (Exception ignored) {
-    }
-  }
-
-  @Test
   public void getStoreById() throws Exception {
     long storeId = 234;
     String testAddress = "testAddress";

--- a/src/test/java/org/tikv/common/RegionStoreClientTest.java
+++ b/src/test/java/org/tikv/common/RegionStoreClientTest.java
@@ -43,7 +43,8 @@ public class RegionStoreClientTest extends MockServerTest {
         new RegionStoreClientBuilder(
             session.getConf(),
             session.getChannelFactory(),
-            new RegionManager(session.getPDClient()));
+            new RegionManager(session.getPDClient()),
+            session.getPDClient());
 
     return builder.build(region, store);
   }

--- a/src/test/java/org/tikv/common/RegionStoreClientTest.java
+++ b/src/test/java/org/tikv/common/RegionStoreClientTest.java
@@ -31,12 +31,21 @@ import org.tikv.kvproto.Metapb;
 
 public class RegionStoreClientTest extends MockServerTest {
 
-  private RegionStoreClient createClient() {
+  private RegionStoreClient createClientV2() {
+    return createClient("2.1.19");
+  }
+
+  private RegionStoreClient createClientV3() {
+    return createClient("3.0.12");
+  }
+
+  private RegionStoreClient createClient(String version) {
     Metapb.Store store =
         Metapb.Store.newBuilder()
             .setAddress(LOCAL_ADDR + ":" + port)
             .setId(1)
             .setState(Metapb.StoreState.Up)
+            .setVersion(version)
             .build();
 
     RegionStoreClientBuilder builder =
@@ -51,7 +60,10 @@ public class RegionStoreClientTest extends MockServerTest {
 
   @Test
   public void rawGetTest() throws Exception {
-    RegionStoreClient client = createClient();
+    doRawGetTest(createClientV3());
+  }
+
+  public void doRawGetTest(RegionStoreClient client) throws Exception {
     server.put("key1", "value1");
     ByteString value = client.rawGet(defaultBackOff(), ByteString.copyFromUtf8("key1"));
     assertEquals(ByteString.copyFromUtf8("value1"), value);
@@ -75,7 +87,10 @@ public class RegionStoreClientTest extends MockServerTest {
 
   @Test
   public void getTest() throws Exception {
-    RegionStoreClient client = createClient();
+    doGetTest(createClientV3());
+  }
+
+  public void doGetTest(RegionStoreClient client) throws Exception {
     server.put("key1", "value1");
     ByteString value = client.get(defaultBackOff(), ByteString.copyFromUtf8("key1"), 1);
     assertEquals(ByteString.copyFromUtf8("value1"), value);
@@ -93,8 +108,10 @@ public class RegionStoreClientTest extends MockServerTest {
 
   @Test
   public void batchGetTest() throws Exception {
-    RegionStoreClient client = createClient();
+    doBatchGetTest(createClientV3());
+  }
 
+  public void doBatchGetTest(RegionStoreClient client) throws Exception {
     server.put("key1", "value1");
     server.put("key2", "value2");
     server.put("key4", "value4");
@@ -126,8 +143,10 @@ public class RegionStoreClientTest extends MockServerTest {
 
   @Test
   public void scanTest() throws Exception {
-    RegionStoreClient client = createClient();
+    doScanTest(createClientV3());
+  }
 
+  public void doScanTest(RegionStoreClient client) throws Exception {
     server.put("key1", "value1");
     server.put("key2", "value2");
     server.put("key4", "value4");

--- a/src/test/java/org/tikv/raw/RawKVClientTest.java
+++ b/src/test/java/org/tikv/raw/RawKVClientTest.java
@@ -6,10 +6,11 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.apache.log4j.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.tikv.common.TiConfiguration;
 import org.tikv.common.TiSession;
 import org.tikv.common.codec.KeyUtils;
@@ -38,7 +39,7 @@ public class RawKVClientTest {
   private static final ExecutorService executors = Executors.newFixedThreadPool(WORKER_CNT);
   private final ExecutorCompletionService<Object> completionService =
       new ExecutorCompletionService<>(executors);
-  private static final Logger logger = Logger.getLogger(RawKVClientTest.class);
+  private static final Logger logger = LoggerFactory.getLogger(RawKVClientTest.class);
   private TiSession session;
 
   static {


### PR DESCRIPTION
Get ready to merge TiKV Java Client with TiSpark Java Client.

Things done:
- separated most logic of tispark java client to `txn` package.
- cherrypicked fixes from TiSpark since December 2019.
