### PR TITLE
Fix enum index out of range error

### DIFF
--- a/src/main/java/org/tikv/common/codec/Codec.java
+++ b/src/main/java/org/tikv/common/codec/Codec.java
@@ -723,6 +723,9 @@ public class Codec {
     }
 
     public static String readEnumFromIndex(int idx, List<String> elems) {
+      if (idx == 0) {
+        return "";
+      }
       if (idx < 0 || idx >= elems.size()) throw new TypeException("Index is out of range");
       return elems.get(idx);
     }


### PR DESCRIPTION
When enum inserted is empty string `''`, its index value is actually 0.

https://dev.mysql.com/doc/refman/8.0/en/enum.html#enum-indexes

Signed-off-by: birdstorm <samuelwyf@hotmail.com>