### PR TITLE
Fix empty enum type

### DIFF
--- a/src/main/java/org/tikv/common/codec/Codec.java
+++ b/src/main/java/org/tikv/common/codec/Codec.java
@@ -723,7 +723,7 @@ public class Codec {
     }
 
     public static String readEnumFromIndex(int idx, List<String> elems) {
-      if (idx == 0) {
+      if (idx == -1) {
         return "";
       }
       if (idx < 0 || idx >= elems.size()) throw new TypeException("Index is out of range");


### PR DESCRIPTION
#106  should be bounded -1 rather than 0, because the value of idx was substracted before.

Signed-off-by: birdstorm <samuelwyf@hotmail.com>