### PR TITLE
Fix falsely shaded dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -416,25 +416,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.1.0</version>
-                <executions>
-                    <execution>
-                        <id>jar</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                        <configuration>
-                            <descriptorRefs>
-                                <descriptorRef>jar-with-dependencies</descriptorRef>
-                            </descriptorRefs>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
             <!-- Code coverage test -->
             <plugin>
                 <groupId>org.jacoco</groupId>

--- a/src/main/java/org/tikv/common/columnar/TiChunkColumnVector.java
+++ b/src/main/java/org/tikv/common/columnar/TiChunkColumnVector.java
@@ -21,7 +21,6 @@ import java.nio.ByteBuffer;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-
 import org.joda.time.LocalDate;
 import org.tikv.common.codec.CodecDataInput;
 import org.tikv.common.codec.MyDecimal;

--- a/src/main/java/org/tikv/common/region/RegionStoreClient.java
+++ b/src/main/java/org/tikv/common/region/RegionStoreClient.java
@@ -1040,7 +1040,8 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
       return build(key, TiStoreType.TiKV);
     }
 
-    public synchronized RegionStoreClient build(ByteString key, TiStoreType storeType) throws GrpcException {
+    public synchronized RegionStoreClient build(ByteString key, TiStoreType storeType)
+        throws GrpcException {
       Pair<TiRegion, Store> pair = regionManager.getRegionStorePairByKey(key, storeType);
       return build(pair.first, pair.second, storeType);
     }


### PR DESCRIPTION
The `maven-assembly` plugin falsely re-introduces shaded dependencies.

It is now removed in this PR.

Signed-off-by: birdstorm <samuelwyf@hotmail.com>