### PR TITLE
Modify TiSession API document

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ public class Main {
 	public static void main() {
 		// You MUST create a raw configuration if you are using RawKVClient.
 		TiConfiguration conf = TiConfiguration.createRawDefault(YOUR_PD_ADDRESSES);
-		TiSession session = TiSession.create(conf);
+		TiSession session = TiSession.getInstance(conf);
 		RawKVClient = session.createRawKVClient();
 	}
 }

--- a/src/main/java/org/tikv/common/TiSession.java
+++ b/src/main/java/org/tikv/common/TiSession.java
@@ -70,6 +70,7 @@ public class TiSession implements AutoCloseable {
     this.client = PDClient.createRaw(conf, channelFactory);
   }
 
+  @VisibleForTesting
   public static TiSession create(TiConfiguration conf) {
     return new TiSession(conf);
   }

--- a/src/test/java/org/tikv/raw/RawKVClientTest.java
+++ b/src/test/java/org/tikv/raw/RawKVClientTest.java
@@ -78,7 +78,7 @@ public class RawKVClientTest {
       data = new TreeMap<>(bsc);
       initialized = true;
     } catch (Exception e) {
-      logger.warn("Cannot initialize raw client. Test skipped.", e);
+      logger.warn("Cannot initialize raw client, please check whether TiKV is running. Test skipped.", e);
     }
   }
 


### PR DESCRIPTION
As shown in examples, users should use `TiSession.getInstance` rather than `TiSession.create` to initialize a `TiSession`. 

Signed-off-by: birdstorm <samuelwyf@hotmail.com>