### PR TITLE
Optimize group region by keys logic

### DIFF
--- a/src/main/java/org/tikv/common/KVClient.java
+++ b/src/main/java/org/tikv/common/KVClient.java
@@ -17,8 +17,7 @@
 
 package org.tikv.common;
 
-import static org.tikv.common.util.ClientUtils.appendBatches;
-import static org.tikv.common.util.ClientUtils.getKvPairs;
+import static org.tikv.common.util.ClientUtils.*;
 
 import com.google.protobuf.ByteString;
 import java.util.ArrayList;
@@ -28,7 +27,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.tikv.common.exception.GrpcException;
@@ -129,7 +127,8 @@ public class KVClient implements AutoCloseable {
     ExecutorCompletionService<List<KvPair>> completionService =
         new ExecutorCompletionService<>(batchGetThreadPool);
 
-    Map<TiRegion, List<ByteString>> groupKeys = groupKeysByRegion(keys);
+    Map<TiRegion, List<ByteString>> groupKeys =
+        groupKeysByRegion(clientBuilder.getRegionManager(), keys, backOffer);
     List<Batch> batches = new ArrayList<>();
 
     for (Map.Entry<TiRegion, List<ByteString>> entry : groupKeys.entrySet()) {
@@ -170,7 +169,8 @@ public class KVClient implements AutoCloseable {
 
   private List<KvPair> doSendBatchGetWithRefetchRegion(
       BackOffer backOffer, Batch batch, long version) {
-    Map<TiRegion, List<ByteString>> groupKeys = groupKeysByRegion(batch.keys);
+    Map<TiRegion, List<ByteString>> groupKeys =
+        groupKeysByRegion(clientBuilder.getRegionManager(), batch.keys, backOffer);
     List<Batch> retryBatches = new ArrayList<>();
 
     for (Map.Entry<TiRegion, List<ByteString>> entry : groupKeys.entrySet()) {
@@ -184,17 +184,6 @@ public class KVClient implements AutoCloseable {
       results.addAll(batchResult);
     }
     return results;
-  }
-
-  /**
-   * Group by list of keys according to its region
-   *
-   * @param keys keys
-   * @return a mapping of keys and their region
-   */
-  private Map<TiRegion, List<ByteString>> groupKeysByRegion(List<ByteString> keys) {
-    return keys.stream()
-        .collect(Collectors.groupingBy(clientBuilder.getRegionManager()::getRegionByKey));
   }
 
   private Iterator<KvPair> scanIterator(

--- a/src/main/java/org/tikv/common/TiSession.java
+++ b/src/main/java/org/tikv/common/TiSession.java
@@ -15,6 +15,8 @@
 
 package org.tikv.common;
 
+import static org.tikv.common.util.ClientUtils.groupKeysByRegion;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.protobuf.ByteString;
@@ -347,7 +349,8 @@ public class TiSession implements AutoCloseable {
   private List<TiRegion> splitRegion(List<ByteString> splitKeys, BackOffer backOffer) {
     List<TiRegion> regions = new ArrayList<>();
 
-    Map<TiRegion, List<ByteString>> groupKeys = groupKeysByRegion(splitKeys);
+    Map<TiRegion, List<ByteString>> groupKeys =
+        groupKeysByRegion(regionManager, splitKeys, backOffer);
     for (Map.Entry<TiRegion, List<ByteString>> entry : groupKeys.entrySet()) {
 
       Pair<TiRegion, Metapb.Store> pair =
@@ -383,11 +386,6 @@ public class TiSession implements AutoCloseable {
 
     logger.info("splitRegion: return region size={}", regions.size());
     return regions;
-  }
-
-  private Map<TiRegion, List<ByteString>> groupKeysByRegion(List<ByteString> keys) {
-    return keys.stream()
-        .collect(Collectors.groupingBy(clientBuilder.getRegionManager()::getRegionByKey));
   }
 
   @Override

--- a/src/main/java/org/tikv/common/util/ClientUtils.java
+++ b/src/main/java/org/tikv/common/util/ClientUtils.java
@@ -83,7 +83,12 @@ public class ClientUtils {
 
   public static Map<TiRegion, List<ByteString>> groupKeysByRegion(
       RegionManager regionManager, Set<ByteString> keys, BackOffer backoffer) {
-    return groupKeysByRegion(regionManager, new ArrayList<>(keys), backoffer);
+    return groupKeysByRegion(regionManager, new ArrayList<>(keys), backoffer, true);
+  }
+
+  public static Map<TiRegion, List<ByteString>> groupKeysByRegion(
+      RegionManager regionManager, List<ByteString> keys, BackOffer backoffer) {
+    return groupKeysByRegion(regionManager, new ArrayList<>(keys), backoffer, false);
   }
 
   /**
@@ -93,9 +98,11 @@ public class ClientUtils {
    * @return a mapping of keys and their region
    */
   public static Map<TiRegion, List<ByteString>> groupKeysByRegion(
-      RegionManager regionManager, List<ByteString> keys, BackOffer backoffer) {
+      RegionManager regionManager, List<ByteString> keys, BackOffer backoffer, boolean sorted) {
     Map<TiRegion, List<ByteString>> groups = new HashMap<>();
-    keys.sort((k1, k2) -> FastByteComparisons.compareTo(k1.toByteArray(), k2.toByteArray()));
+    if (!sorted) {
+      keys.sort((k1, k2) -> FastByteComparisons.compareTo(k1.toByteArray(), k2.toByteArray()));
+    }
     TiRegion lastRegion = null;
     for (ByteString key : keys) {
       if (lastRegion == null || !lastRegion.contains(key)) {


### PR DESCRIPTION
In the previous implementation, each key to be grouped should go through the getRegionByKey logic.

But since we know the regions changed which locates the keys in advance, those keys in the same region do not need to go through the same logic again. 

Signed-off-by: birdstorm <samuelwyf@hotmail.com>