### PR TITLE
Add Network Mapping

### DIFF
--- a/src/main/java/org/tikv/common/ConfigUtils.java
+++ b/src/main/java/org/tikv/common/ConfigUtils.java
@@ -47,6 +47,8 @@ public class ConfigUtils {
   public static final String TIKV_METRICS_ENABLE = "tikv.metrics.enable";
   public static final String TIKV_METRICS_PORT = "tikv.metrics.port";
 
+  public static final String TIKV_NETWORK_MAPPING_NAME = "tikv.network.mapping";
+
   public static final String DEF_PD_ADDRESSES = "127.0.0.1:2379";
   public static final String DEF_TIMEOUT = "600ms";
   public static final String DEF_SCAN_TIMEOUT = "20s";
@@ -73,6 +75,7 @@ public class ConfigUtils {
   public static final boolean DEF_IS_REPLICA_READ = false;
   public static final boolean DEF_METRICS_ENABLE = false;
   public static final int DEF_METRICS_PORT = 3140;
+  public static final String DEF_TIKV_NETWORK_MAPPING_NAME = "";
 
   public static final String NORMAL_COMMAND_PRIORITY = "NORMAL";
   public static final String LOW_COMMAND_PRIORITY = "LOW";

--- a/src/main/java/org/tikv/common/HostMapping.java
+++ b/src/main/java/org/tikv/common/HostMapping.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2021 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.tikv.common;
+
+import static org.tikv.common.pd.PDUtils.addrToUri;
+
+import com.google.common.annotations.Beta;
+import io.etcd.jetcd.ByteSequence;
+import io.etcd.jetcd.Client;
+import io.etcd.jetcd.KeyValue;
+import io.etcd.jetcd.kv.GetResponse;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class HostMapping {
+  private static final String NETWORK_MAPPING_PATH = "/client/url-mapping";
+  private final Client etcdClient;
+  private final String networkMappingName;
+  private final ConcurrentMap<String, String> hostMapping;
+  private final Logger logger = LoggerFactory.getLogger(HostMapping.class);
+
+  public HostMapping(Client etcdClient, String networkMappingName) {
+    this.etcdClient = etcdClient;
+    this.networkMappingName = networkMappingName;
+    this.hostMapping = new ConcurrentHashMap<>();
+  }
+
+  private ByteSequence hostToNetworkMappingKey(String host) {
+    String path = NETWORK_MAPPING_PATH + "/" + networkMappingName + "/" + host;
+    return ByteSequence.from(path, StandardCharsets.UTF_8);
+  }
+
+  @Beta
+  private String getMappedHostFromPD(String host) {
+    ByteSequence hostKey = hostToNetworkMappingKey(host);
+    for (int i = 0; i < 5; i++) {
+      CompletableFuture<GetResponse> future = etcdClient.getKVClient().get(hostKey);
+      try {
+        GetResponse resp = future.get();
+        List<KeyValue> kvs = resp.getKvs();
+        if (kvs.size() != 1) {
+          break;
+        }
+        return kvs.get(0).getValue().toString();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      } catch (ExecutionException e) {
+        logger.info("failed to get mapped Host from PD: " + host, e);
+        break;
+      } catch (Exception ignore) {
+        // ignore
+        break;
+      }
+    }
+    return host;
+  }
+
+  public URI getMappedURI(URI uri) {
+    if (networkMappingName.isEmpty()) {
+      return uri;
+    }
+    return addrToUri(
+        hostMapping.computeIfAbsent(uri.getHost(), this::getMappedHostFromPD)
+            + ":"
+            + uri.getPort());
+  }
+}

--- a/src/main/java/org/tikv/common/HostMapping.java
+++ b/src/main/java/org/tikv/common/HostMapping.java
@@ -61,7 +61,7 @@ public class HostMapping {
         if (kvs.size() != 1) {
           break;
         }
-        return kvs.get(0).getValue().toString();
+        return kvs.get(0).getValue().toString(StandardCharsets.UTF_8);
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
       } catch (ExecutionException e) {

--- a/src/main/java/org/tikv/common/PDClient.java
+++ b/src/main/java/org/tikv/common/PDClient.java
@@ -431,7 +431,7 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDStub>
 
   private GetMembersResponse getMembers(URI uri) {
     try {
-      ManagedChannel probChan = channelFactory.getChannel(uriToAddr(uri), this);
+      ManagedChannel probChan = channelFactory.getChannel(uriToAddr(uri));
       PDGrpc.PDBlockingStub stub = PDGrpc.newBlockingStub(probChan);
       GetMembersRequest request =
           GetMembersRequest.newBuilder().setHeader(RequestHeader.getDefaultInstance()).build();
@@ -467,7 +467,7 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDStub>
       }
 
       // create new Leader
-      ManagedChannel clientChannel = channelFactory.getChannel(leaderUrlStr, this);
+      ManagedChannel clientChannel = channelFactory.getChannel(leaderUrlStr);
       leaderWrapper =
           new LeaderWrapper(
               leaderUrlStr,

--- a/src/main/java/org/tikv/common/ReadOnlyPDClient.java
+++ b/src/main/java/org/tikv/common/ReadOnlyPDClient.java
@@ -16,7 +16,6 @@
 package org.tikv.common;
 
 import com.google.protobuf.ByteString;
-import java.net.URI;
 import java.util.List;
 import java.util.concurrent.Future;
 import org.tikv.common.meta.TiTimestamp;
@@ -53,7 +52,7 @@ public interface ReadOnlyPDClient {
 
   Future<TiRegion> getRegionByIDAsync(BackOffer backOffer, long id);
 
-  URI getMappedURI(URI uri);
+  HostMapping getHostMapping();
 
   /**
    * Get Store by StoreId

--- a/src/main/java/org/tikv/common/ReadOnlyPDClient.java
+++ b/src/main/java/org/tikv/common/ReadOnlyPDClient.java
@@ -16,6 +16,7 @@
 package org.tikv.common;
 
 import com.google.protobuf.ByteString;
+import java.net.URI;
 import java.util.List;
 import java.util.concurrent.Future;
 import org.tikv.common.meta.TiTimestamp;
@@ -51,6 +52,8 @@ public interface ReadOnlyPDClient {
   TiRegion getRegionByID(BackOffer backOffer, long id);
 
   Future<TiRegion> getRegionByIDAsync(BackOffer backOffer, long id);
+
+  URI getMappedURI(URI uri);
 
   /**
    * Get Store by StoreId

--- a/src/main/java/org/tikv/common/TiConfiguration.java
+++ b/src/main/java/org/tikv/common/TiConfiguration.java
@@ -239,6 +239,8 @@ public class TiConfiguration implements Serializable {
   private boolean metricsEnable = getBoolean(TIKV_METRICS_ENABLE);
   private int metricsPort = getInt(TIKV_METRICS_PORT);
 
+  private final String networkMappingName = get(TIKV_NETWORK_MAPPING_NAME);
+
   public enum KVMode {
     TXN,
     RAW
@@ -479,5 +481,9 @@ public class TiConfiguration implements Serializable {
   public TiConfiguration setMetricsPort(int metricsPort) {
     this.metricsPort = metricsPort;
     return this;
+  }
+
+  public String getNetworkMappingName() {
+    return this.networkMappingName;
   }
 }

--- a/src/main/java/org/tikv/common/TiConfiguration.java
+++ b/src/main/java/org/tikv/common/TiConfiguration.java
@@ -70,6 +70,7 @@ public class TiConfiguration implements Serializable {
     setIfMissing(TIKV_IS_REPLICA_READ, DEF_IS_REPLICA_READ);
     setIfMissing(TIKV_METRICS_ENABLE, DEF_METRICS_ENABLE);
     setIfMissing(TIKV_METRICS_PORT, DEF_METRICS_PORT);
+    setIfMissing(TIKV_NETWORK_MAPPING_NAME, DEF_TIKV_NETWORK_MAPPING_NAME);
   }
 
   public static void listAll() {

--- a/src/main/java/org/tikv/common/pd/PDUtils.java
+++ b/src/main/java/org/tikv/common/pd/PDUtils.java
@@ -20,7 +20,7 @@ import java.net.URI;
 import java.util.List;
 
 public class PDUtils {
-  public static URI addrToUrl(String addr) {
+  public static URI addrToUri(String addr) {
     if (addr.contains("://")) {
       return URI.create(addr);
     } else {
@@ -31,8 +31,12 @@ public class PDUtils {
   public static List<URI> addrsToUrls(String[] addrs) {
     ImmutableList.Builder<URI> urlsBuilder = new ImmutableList.Builder<>();
     for (String addr : addrs) {
-      urlsBuilder.add(addrToUrl(addr));
+      urlsBuilder.add(addrToUri(addr));
     }
     return urlsBuilder.build();
+  }
+
+  public static String uriToAddr(URI uri) {
+    return uri.getHost() + ":" + uri.getPort();
   }
 }

--- a/src/main/java/org/tikv/common/region/AbstractRegionStoreClient.java
+++ b/src/main/java/org/tikv/common/region/AbstractRegionStoreClient.java
@@ -87,7 +87,7 @@ public abstract class AbstractRegionStoreClient
     }
     region = newRegion;
     String addressStr = regionManager.getStoreById(region.getLeader().getStoreId()).getAddress();
-    ManagedChannel channel = channelFactory.getChannel(addressStr);
+    ManagedChannel channel = channelFactory.getChannel(addressStr, regionManager.getPDClient());
     blockingStub = TikvGrpc.newBlockingStub(channel);
     asyncStub = TikvGrpc.newStub(channel);
     return true;
@@ -96,7 +96,7 @@ public abstract class AbstractRegionStoreClient
   @Override
   public void onStoreNotMatch(Metapb.Store store) {
     String addressStr = store.getAddress();
-    ManagedChannel channel = channelFactory.getChannel(addressStr);
+    ManagedChannel channel = channelFactory.getChannel(addressStr, regionManager.getPDClient());
     blockingStub = TikvGrpc.newBlockingStub(channel);
     asyncStub = TikvGrpc.newStub(channel);
     if (region.getLeader().getStoreId() != store.getId()) {

--- a/src/main/java/org/tikv/common/region/AbstractRegionStoreClient.java
+++ b/src/main/java/org/tikv/common/region/AbstractRegionStoreClient.java
@@ -87,7 +87,8 @@ public abstract class AbstractRegionStoreClient
     }
     region = newRegion;
     String addressStr = regionManager.getStoreById(region.getLeader().getStoreId()).getAddress();
-    ManagedChannel channel = channelFactory.getChannel(addressStr, regionManager.getPDClient());
+    ManagedChannel channel =
+        channelFactory.getChannel(addressStr, regionManager.getPDClient().getHostMapping());
     blockingStub = TikvGrpc.newBlockingStub(channel);
     asyncStub = TikvGrpc.newStub(channel);
     return true;
@@ -96,7 +97,8 @@ public abstract class AbstractRegionStoreClient
   @Override
   public void onStoreNotMatch(Metapb.Store store) {
     String addressStr = store.getAddress();
-    ManagedChannel channel = channelFactory.getChannel(addressStr, regionManager.getPDClient());
+    ManagedChannel channel =
+        channelFactory.getChannel(addressStr, regionManager.getPDClient().getHostMapping());
     blockingStub = TikvGrpc.newBlockingStub(channel);
     asyncStub = TikvGrpc.newStub(channel);
     if (region.getLeader().getStoreId() != store.getId()) {

--- a/src/main/java/org/tikv/common/region/RegionManager.java
+++ b/src/main/java/org/tikv/common/region/RegionManager.java
@@ -79,6 +79,10 @@ public class RegionManager {
     return cacheInvalidateCallback;
   }
 
+  public ReadOnlyPDClient getPDClient() {
+    return this.cache.pdClient;
+  }
+
   public TiRegion getRegionByKey(ByteString key) {
     return getRegionByKey(key, ConcreteBackOffer.newGetBackOff());
   }

--- a/src/main/java/org/tikv/common/region/RegionStoreClient.java
+++ b/src/main/java/org/tikv/common/region/RegionStoreClient.java
@@ -119,7 +119,7 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
       if (logger.isDebugEnabled()) {
         logger.debug(String.format("Create region store client on address %s", addressStr));
       }
-      ManagedChannel channel = channelFactory.getChannel(addressStr);
+      ManagedChannel channel = channelFactory.getChannel(addressStr, pdClient);
 
       TikvBlockingStub tikvBlockingStub = TikvGrpc.newBlockingStub(channel);
       TikvStub tikvAsyncStub = TikvGrpc.newStub(channel);
@@ -1239,7 +1239,7 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
       if (logger.isDebugEnabled()) {
         logger.debug(String.format("Create region store client on address %s", addressStr));
       }
-      ManagedChannel channel = channelFactory.getChannel(addressStr);
+      ManagedChannel channel = channelFactory.getChannel(addressStr, pdClient);
 
       TikvBlockingStub blockingStub = TikvGrpc.newBlockingStub(channel);
       TikvStub asyncStub = TikvGrpc.newStub(channel);

--- a/src/main/java/org/tikv/common/region/RegionStoreClient.java
+++ b/src/main/java/org/tikv/common/region/RegionStoreClient.java
@@ -120,7 +120,6 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
         logger.debug(String.format("Create region store client on address %s", addressStr));
       }
       ManagedChannel channel = channelFactory.getChannel(addressStr, pdClient.getHostMapping());
-      logger.info("created channel " + channel.toString());
 
       TikvBlockingStub tikvBlockingStub = TikvGrpc.newBlockingStub(channel);
       TikvStub tikvAsyncStub = TikvGrpc.newStub(channel);

--- a/src/main/java/org/tikv/common/region/RegionStoreClient.java
+++ b/src/main/java/org/tikv/common/region/RegionStoreClient.java
@@ -119,7 +119,8 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
       if (logger.isDebugEnabled()) {
         logger.debug(String.format("Create region store client on address %s", addressStr));
       }
-      ManagedChannel channel = channelFactory.getChannel(addressStr, pdClient);
+      ManagedChannel channel = channelFactory.getChannel(addressStr, pdClient.getHostMapping());
+      logger.info("created channel " + channel.toString());
 
       TikvBlockingStub tikvBlockingStub = TikvGrpc.newBlockingStub(channel);
       TikvStub tikvAsyncStub = TikvGrpc.newStub(channel);
@@ -1239,7 +1240,7 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
       if (logger.isDebugEnabled()) {
         logger.debug(String.format("Create region store client on address %s", addressStr));
       }
-      ManagedChannel channel = channelFactory.getChannel(addressStr, pdClient);
+      ManagedChannel channel = channelFactory.getChannel(addressStr, pdClient.getHostMapping());
 
       TikvBlockingStub blockingStub = TikvGrpc.newBlockingStub(channel);
       TikvStub asyncStub = TikvGrpc.newStub(channel);

--- a/src/main/java/org/tikv/common/util/ChannelFactory.java
+++ b/src/main/java/org/tikv/common/util/ChannelFactory.java
@@ -20,15 +20,12 @@ import io.grpc.ManagedChannelBuilder;
 import java.net.URI;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.tikv.common.HostMapping;
 import org.tikv.common.pd.PDUtils;
 
 public class ChannelFactory implements AutoCloseable {
   private final int maxFrameSize;
   private final ConcurrentHashMap<String, ManagedChannel> connPool = new ConcurrentHashMap<>();
-  private final Logger logger = LoggerFactory.getLogger(ChannelFactory.class);
 
   public ChannelFactory(int maxFrameSize) {
     this.maxFrameSize = maxFrameSize;
@@ -47,7 +44,6 @@ public class ChannelFactory implements AutoCloseable {
           }
           try {
             mappedAddr = hostMapping.getMappedURI(address);
-            logger.info("maps " + address.getHost() + " to " + mappedAddr.getHost());
           } catch (Exception e) {
             throw new IllegalArgumentException("failed to get mapped address " + address, e);
           }

--- a/src/main/java/org/tikv/common/util/RangeSplitter.java
+++ b/src/main/java/org/tikv/common/util/RangeSplitter.java
@@ -231,7 +231,7 @@ public class RangeSplitter {
       this.ranges = ranges;
       String host = null;
       try {
-        host = PDUtils.addrToUrl(store.getAddress()).getHost();
+        host = PDUtils.addrToUri(store.getAddress()).getHost();
       } catch (Exception ignored) {
       }
       this.host = host;


### PR DESCRIPTION
Add network mapping for Java Client.

By using `-Dtikv.network.mapping=<config-name>`, we can make the client use the corresponding host mapping strategy stored in PD's ETCD in advance.

The format of KV is as follows:
```
key: /client/url-mapping/<conf-name>/<Inet-ip>
value: <mapped-ip>
```