### PR TITLE
invalidate all region cache on store when store id not found

### DIFF
--- a/src/main/java/org/tikv/common/region/RegionManager.java
+++ b/src/main/java/org/tikv/common/region/RegionManager.java
@@ -129,9 +129,16 @@ public class RegionManager {
       if (isReplicaRead) {
         Peer peer = region.getCurrentFollower();
         store = cache.getStoreById(peer.getStoreId(), backOffer);
+        if (store == null) {
+          cache.invalidateRegion(region);
+        }
       } else {
         Peer leader = region.getLeader();
-        store = cache.getStoreById(leader.getStoreId(), backOffer);
+        long storeId = leader.getStoreId();
+        store = cache.getStoreById(storeId, backOffer);
+        if (store == null) {
+          cache.invalidateAllRegionForStore(storeId);
+        }
       }
     } else {
       outerLoop:

--- a/src/main/java/org/tikv/common/region/RegionManager.java
+++ b/src/main/java/org/tikv/common/region/RegionManager.java
@@ -134,10 +134,9 @@ public class RegionManager {
         }
       } else {
         Peer leader = region.getLeader();
-        long storeId = leader.getStoreId();
-        store = cache.getStoreById(storeId, backOffer);
+        store = cache.getStoreById(leader.getStoreId(), backOffer);
         if (store == null) {
-          cache.invalidateAllRegionForStore(storeId);
+          cache.clearAll();
         }
       }
     } else {
@@ -323,8 +322,8 @@ public class RegionManager {
 
       // remove region
       for (TiRegion r : regionToRemove) {
-        regionCache.remove(r.getId());
         keyToRegionIdCache.remove(makeRange(r.getStartKey(), r.getEndKey()));
+        regionCache.remove(r.getId());
       }
     }
 
@@ -346,6 +345,11 @@ public class RegionManager {
       } catch (Exception e) {
         throw new GrpcException(e);
       }
+    }
+
+    public synchronized void clearAll() {
+      keyToRegionIdCache.clear();
+      regionCache.clear();
     }
   }
 }


### PR DESCRIPTION
Signed-off-by: birdstorm <samuelwyf@hotmail.com>

### What problem does this PR solve? <!--add issue link with summary if exists-->
When store id does not exist in PD, we should invalidate all RegionCache on this store

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)