### PR TITLE
Fix pd retry not recovered for 60s

### DIFF
--- a/src/main/java/org/tikv/common/PDClient.java
+++ b/src/main/java/org/tikv/common/PDClient.java
@@ -418,7 +418,7 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDStub>
     return createLeaderWrapper(leaderUrlStr);
   }
 
-  private boolean createLeaderWrapper(String leaderUrlStr) {
+  private synchronized boolean createLeaderWrapper(String leaderUrlStr) {
     try {
       URI newLeader = addrToUri(leaderUrlStr);
       leaderUrlStr = uriToAddr(newLeader);

--- a/src/main/java/org/tikv/common/operation/PDErrorHandler.java
+++ b/src/main/java/org/tikv/common/operation/PDErrorHandler.java
@@ -73,6 +73,7 @@ public class PDErrorHandler<RespT> implements ErrorHandler<RespT> {
   @Override
   public boolean handleRequestError(BackOffer backOffer, Exception e) {
     backOffer.doBackOff(BackOffFunction.BackOffFuncType.BoPDRPC, e);
+    client.updateLeader();
     return true;
   }
 }

--- a/src/test/java/org/tikv/common/PDMockServer.java
+++ b/src/test/java/org/tikv/common/PDMockServer.java
@@ -43,7 +43,7 @@ public class PDMockServer extends PDGrpc.PDImplBase {
   @Override
   public void getMembers(GetMembersRequest request, StreamObserver<GetMembersResponse> resp) {
     try {
-      resp.onNext(getMembersResp.removeFirst().get());
+      resp.onNext(getMembersResp.getFirst().get());
       resp.onCompleted();
     } catch (Exception e) {
       resp.onError(Status.INTERNAL.asRuntimeException());


### PR DESCRIPTION
Signed-off-by: birdstorm <samuelwyf@hotmail.com>

close https://github.com/tikv/client-java/issues/179

When PD request is retried when leader is down, the leader info is not updated, so it will fail for at least 60s until the leader info is correct.

 - Need to cherry-pick to the release branch
