### PR TITLE
Refactor RawKVClient CAS API

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,5 +176,9 @@ The following includes ThreadPool related parameters, which can be passed in thr
 - the thread pool size of deleteRange on client side
 - default: 20
 
+#### tikv.enable_atomic_for_cas
+- whether to enable Compare And Swap, set true if using `RawKVClient.compareAndSet` or `RawKVClient.putIfAbsent`
+- default: false
+
 ## License
 Apache 2.0 license. See the [LICENSE](./LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ The following includes ThreadPool related parameters, which can be passed in thr
 - default: 20
 
 #### tikv.enable_atomic_for_cas
-- whether to enable Compare And Swap, set true if using `RawKVClient.compareAndSet` or `RawKVClient.putIfAbsent`
+- whether to enable `Compare And Set`, set true if using `RawKVClient.compareAndSet` or `RawKVClient.putIfAbsent`
 - default: false
 
 ## License

--- a/src/main/java/org/tikv/common/ConfigUtils.java
+++ b/src/main/java/org/tikv/common/ConfigUtils.java
@@ -51,6 +51,8 @@ public class ConfigUtils {
   public static final String TIKV_ENABLE_GRPC_FORWARD = "tikv.enable_grpc_forward";
   public static final String TIKV_GRPC_HEALTH_CHECK_TIMEOUT = "tikv.grpc.health_check_timeout";
 
+  public static final String TIKV_ENABLE_ATOMIC_FOR_CAS = "tikv.enable_atomic_for_cas";
+
   public static final String DEF_PD_ADDRESSES = "127.0.0.1:2379";
   public static final String DEF_TIMEOUT = "600ms";
   public static final String DEF_SCAN_TIMEOUT = "20s";
@@ -80,6 +82,7 @@ public class ConfigUtils {
   public static final int DEF_METRICS_PORT = 3140;
   public static final String DEF_TIKV_NETWORK_MAPPING_NAME = "";
   public static final boolean DEF_GRPC_FORWARD_ENABLE = true;
+  public static final boolean DEF_TIKV_ENABLE_ATOMIC_FOR_CAS = false;
 
   public static final String NORMAL_COMMAND_PRIORITY = "NORMAL";
   public static final String LOW_COMMAND_PRIORITY = "LOW";

--- a/src/main/java/org/tikv/common/TiConfiguration.java
+++ b/src/main/java/org/tikv/common/TiConfiguration.java
@@ -79,6 +79,7 @@ public class TiConfiguration implements Serializable {
     setIfMissing(TIKV_NETWORK_MAPPING_NAME, DEF_TIKV_NETWORK_MAPPING_NAME);
     setIfMissing(TIKV_ENABLE_GRPC_FORWARD, DEF_GRPC_FORWARD_ENABLE);
     setIfMissing(TIKV_GRPC_HEALTH_CHECK_TIMEOUT, DEF_CHECK_HEALTH_TIMEOUT);
+    setIfMissing(TIKV_ENABLE_ATOMIC_FOR_CAS, DEF_TIKV_ENABLE_ATOMIC_FOR_CAS);
   }
 
   public static void listAll() {
@@ -265,6 +266,8 @@ public class TiConfiguration implements Serializable {
 
   private final String networkMappingName = get(TIKV_NETWORK_MAPPING_NAME);
   private HostMapping hostMapping = null;
+
+  private boolean enableAtomicForCAS = getBoolean(TIKV_ENABLE_ATOMIC_FOR_CAS);
 
   public enum KVMode {
     TXN,
@@ -557,5 +560,13 @@ public class TiConfiguration implements Serializable {
 
   public long getGrpcHealthCheckTimeout() {
     return this.grpcHealthCheckTimeout;
+  }
+
+  public boolean isEnableAtomicForCAS() {
+    return enableAtomicForCAS;
+  }
+
+  public void setEnableAtomicForCAS(boolean enableAtomicForCAS) {
+    this.enableAtomicForCAS = enableAtomicForCAS;
   }
 }

--- a/src/main/java/org/tikv/common/region/RegionStoreClient.java
+++ b/src/main/java/org/tikv/common/region/RegionStoreClient.java
@@ -865,7 +865,7 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
     return Optional.of(resp.getTtl());
   }
 
-  public void rawDelete(BackOffer backOffer, ByteString key) {
+  public void rawDelete(BackOffer backOffer, ByteString key, boolean atomicForCAS) {
     Histogram.Timer requestTimer =
         GRPC_RAW_REQUEST_LATENCY.labels("client_grpc_raw_delete").startTimer();
     try {
@@ -874,6 +874,7 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
               RawDeleteRequest.newBuilder()
                   .setContext(region.getReplicaContext(storeType))
                   .setKey(key)
+                  .setForCas(atomicForCAS)
                   .build();
 
       RegionErrorHandler<RawDeleteResponse> handler =
@@ -901,7 +902,8 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
     }
   }
 
-  public void rawPut(BackOffer backOffer, ByteString key, ByteString value, long ttl) {
+  public void rawPut(
+      BackOffer backOffer, ByteString key, ByteString value, long ttl, boolean atomicForCAS) {
     Histogram.Timer requestTimer =
         GRPC_RAW_REQUEST_LATENCY.labels("client_grpc_raw_put").startTimer();
     try {
@@ -912,6 +914,7 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
                   .setKey(key)
                   .setValue(value)
                   .setTtl(ttl)
+                  .setForCas(atomicForCAS)
                   .build();
 
       RegionErrorHandler<RawPutResponse> handler =
@@ -1029,7 +1032,8 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
     return resp.getPairsList();
   }
 
-  public void rawBatchPut(BackOffer backOffer, List<KvPair> kvPairs, long ttl, boolean atomic) {
+  public void rawBatchPut(
+      BackOffer backOffer, List<KvPair> kvPairs, long ttl, boolean atomicForCAS) {
     Histogram.Timer requestTimer =
         GRPC_RAW_REQUEST_LATENCY.labels("client_grpc_raw_batch_put").startTimer();
     try {
@@ -1042,7 +1046,7 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
                   .setContext(region.getReplicaContext(storeType))
                   .addAllPairs(kvPairs)
                   .setTtl(ttl)
-                  .setForCas(atomic)
+                  .setForCas(atomicForCAS)
                   .build();
       RegionErrorHandler<RawBatchPutResponse> handler =
           new RegionErrorHandler<RawBatchPutResponse>(
@@ -1055,7 +1059,7 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
     }
   }
 
-  public void rawBatchPut(BackOffer backOffer, Batch batch, long ttl, boolean atomic) {
+  public void rawBatchPut(BackOffer backOffer, Batch batch, long ttl, boolean atomicForCAS) {
     List<KvPair> pairs = new ArrayList<>();
     for (int i = 0; i < batch.getKeys().size(); i++) {
       pairs.add(
@@ -1064,7 +1068,7 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
               .setValue(batch.getValues().get(i))
               .build());
     }
-    rawBatchPut(backOffer, pairs, ttl, atomic);
+    rawBatchPut(backOffer, pairs, ttl, atomicForCAS);
   }
 
   private void handleRawBatchPut(RawBatchPutResponse resp) {
@@ -1081,7 +1085,7 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
     }
   }
 
-  public void rawBatchDelete(BackOffer backoffer, List<ByteString> keys, boolean atomic) {
+  public void rawBatchDelete(BackOffer backoffer, List<ByteString> keys, boolean atomicForCAS) {
     Histogram.Timer requestTimer =
         GRPC_RAW_REQUEST_LATENCY.labels("client_grpc_raw_batch_delete").startTimer();
     try {
@@ -1093,7 +1097,7 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
               RawBatchDeleteRequest.newBuilder()
                   .setContext(region.getReplicaContext(storeType))
                   .addAllKeys(keys)
-                  .setForCas(atomic)
+                  .setForCas(atomicForCAS)
                   .build();
       RegionErrorHandler<RawBatchDeleteResponse> handler =
           new RegionErrorHandler<RawBatchDeleteResponse>(

--- a/src/main/java/org/tikv/raw/RawKVClient.java
+++ b/src/main/java/org/tikv/raw/RawKVClient.java
@@ -40,6 +40,7 @@ import org.tikv.kvproto.Kvrpcpb.KvPair;
 public class RawKVClient implements AutoCloseable {
   private final RegionStoreClientBuilder clientBuilder;
   private final TiConfiguration conf;
+  private final boolean atomicForCAS;
   private final ExecutorService batchGetThreadPool;
   private final ExecutorService batchPutThreadPool;
   private final ExecutorService batchDeleteThreadPool;
@@ -90,6 +91,7 @@ public class RawKVClient implements AutoCloseable {
     this.batchDeleteThreadPool = session.getThreadPoolForBatchDelete();
     this.batchScanThreadPool = session.getThreadPoolForBatchScan();
     this.deleteRangeThreadPool = session.getThreadPoolForDeleteRange();
+    this.atomicForCAS = conf.isEnableAtomicForCAS();
   }
 
   @Override
@@ -120,7 +122,7 @@ public class RawKVClient implements AutoCloseable {
       while (true) {
         RegionStoreClient client = clientBuilder.build(key);
         try {
-          client.rawPut(backOffer, key, value, ttl);
+          client.rawPut(backOffer, key, value, ttl, atomicForCAS);
           RAW_REQUEST_SUCCESS.labels(label).inc();
           return;
         } catch (final TiKVException e) {
@@ -138,6 +140,8 @@ public class RawKVClient implements AutoCloseable {
   /**
    * Put a key-value pair if it does not exist. This API is atomic.
    *
+   * <p>To use this API, please enable `tikv.enable_atomic_for_cas`.
+   *
    * @param key key
    * @param value value
    * @return a ByteString. returns Optional.EMPTY if the value is written successfully. returns the
@@ -149,6 +153,8 @@ public class RawKVClient implements AutoCloseable {
 
   /**
    * Put a key-value pair with TTL if it does not exist. This API is atomic.
+   *
+   * <p>To use this API, please enable `tikv.enable_atomic_for_cas`.
    *
    * @param key key
    * @param value value
@@ -168,6 +174,8 @@ public class RawKVClient implements AutoCloseable {
   /**
    * Put a key-value pair if the prevValue matched the value in TiKV. This API is atomic.
    *
+   * <p>To use this API, please enable `tikv.enable_atomic_for_cas`.
+   *
    * @param key key
    * @param value value
    */
@@ -179,6 +187,8 @@ public class RawKVClient implements AutoCloseable {
   /**
    * pair if the prevValue matched the value in TiKV. This API is atomic.
    *
+   * <p>To use this API, please enable `tikv.enable_atomic_for_cas`.
+   *
    * @param key key
    * @param value value
    * @param ttl TTL of key (in seconds), 0 means the key will never be outdated.
@@ -186,6 +196,11 @@ public class RawKVClient implements AutoCloseable {
   public void compareAndSet(
       ByteString key, Optional<ByteString> prevValue, ByteString value, long ttl)
       throws RawCASConflictException {
+    if (!atomicForCAS) {
+      throw new IllegalArgumentException(
+          "To use Compare And Swap, please enable the config tikv.enable_atomic_for_cas.");
+    }
+
     String label = "client_raw_compare_and_set";
     Histogram.Timer requestTimer = RAW_REQUEST_LATENCY.labels(label).startTimer();
     try {
@@ -209,7 +224,7 @@ public class RawKVClient implements AutoCloseable {
   }
 
   /**
-   * Put a set of raw key-value pair to TiKV, this API does not ensure the operation is atomic.
+   * Put a set of raw key-value pair to TiKV.
    *
    * @param kvPairs kvPairs
    */
@@ -218,39 +233,16 @@ public class RawKVClient implements AutoCloseable {
   }
 
   /**
-   * Put a set of raw key-value pair to TiKV, this API does not ensure the operation is atomic.
+   * Put a set of raw key-value pair to TiKV.
    *
    * @param kvPairs kvPairs
    * @param ttl the TTL of keys to be put (in seconds), 0 means the keys will never be outdated
    */
   public void batchPut(Map<ByteString, ByteString> kvPairs, long ttl) {
-    batchPut(kvPairs, ttl, false);
-  }
-
-  /**
-   * Put a set of raw key-value pair to TiKV, this API is atomic
-   *
-   * @param kvPairs kvPairs
-   */
-  public void batchPutAtomic(Map<ByteString, ByteString> kvPairs) {
-    batchPutAtomic(kvPairs, 0);
-  }
-
-  /**
-   * Put a set of raw key-value pair to TiKV, this API is atomic.
-   *
-   * @param kvPairs kvPairs
-   * @param ttl the TTL of keys to be put (in seconds), 0 means the keys will never be outdated
-   */
-  public void batchPutAtomic(Map<ByteString, ByteString> kvPairs, long ttl) {
-    batchPut(kvPairs, ttl, true);
-  }
-
-  private void batchPut(Map<ByteString, ByteString> kvPairs, long ttl, boolean atomic) {
     String label = "client_raw_batch_put";
     Histogram.Timer requestTimer = RAW_REQUEST_LATENCY.labels(label).startTimer();
     try {
-      doSendBatchPut(ConcreteBackOffer.newRawKVBackOff(), kvPairs, ttl, atomic);
+      doSendBatchPut(ConcreteBackOffer.newRawKVBackOff(), kvPairs, ttl);
       RAW_REQUEST_SUCCESS.labels(label).inc();
     } catch (Exception e) {
       RAW_REQUEST_FAILURE.labels(label).inc();
@@ -317,24 +309,11 @@ public class RawKVClient implements AutoCloseable {
    * @param keys list of raw key
    */
   public void batchDelete(List<ByteString> keys) {
-    batchDelete(keys, false);
-  }
-
-  /**
-   * Delete a list of raw key-value pair from TiKV if key exists, this API is atomic
-   *
-   * @param keys list of raw key
-   */
-  public void batchDeleteAtomic(List<ByteString> keys) {
-    batchDelete(keys, true);
-  }
-
-  private void batchDelete(List<ByteString> keys, boolean atomic) {
     String label = "client_raw_batch_delete";
     Histogram.Timer requestTimer = RAW_REQUEST_LATENCY.labels(label).startTimer();
     try {
       BackOffer backOffer = defaultBackOff();
-      doSendBatchDelete(backOffer, keys, atomic);
+      doSendBatchDelete(backOffer, keys);
       RAW_REQUEST_SUCCESS.labels(label).inc();
       return;
     } catch (Exception e) {
@@ -608,7 +587,7 @@ public class RawKVClient implements AutoCloseable {
       while (true) {
         RegionStoreClient client = clientBuilder.build(key);
         try {
-          client.rawDelete(defaultBackOff(), key);
+          client.rawDelete(defaultBackOff(), key, atomicForCAS);
           RAW_REQUEST_SUCCESS.labels(label).inc();
           return;
         } catch (final TiKVException e) {
@@ -660,8 +639,7 @@ public class RawKVClient implements AutoCloseable {
     deleteRange(key, endKey);
   }
 
-  private void doSendBatchPut(
-      BackOffer backOffer, Map<ByteString, ByteString> kvPairs, long ttl, boolean atomic) {
+  private void doSendBatchPut(BackOffer backOffer, Map<ByteString, ByteString> kvPairs, long ttl) {
     ExecutorCompletionService<List<Batch>> completionService =
         new ExecutorCompletionService<>(batchPutThreadPool);
 
@@ -686,16 +664,15 @@ public class RawKVClient implements AutoCloseable {
       List<Batch> task = taskQueue.poll();
       for (Batch batch : task) {
         completionService.submit(
-            () -> doSendBatchPutInBatchesWithRetry(batch.getBackOffer(), batch, ttl, atomic));
+            () -> doSendBatchPutInBatchesWithRetry(batch.getBackOffer(), batch, ttl));
       }
       getTasks(completionService, taskQueue, task, BackOffer.RAWKV_MAX_BACKOFF);
     }
   }
 
-  private List<Batch> doSendBatchPutInBatchesWithRetry(
-      BackOffer backOffer, Batch batch, long ttl, boolean atomic) {
+  private List<Batch> doSendBatchPutInBatchesWithRetry(BackOffer backOffer, Batch batch, long ttl) {
     try (RegionStoreClient client = clientBuilder.build(batch.getRegion())) {
-      client.rawBatchPut(backOffer, batch, ttl, atomic);
+      client.rawBatchPut(backOffer, batch, ttl, atomicForCAS);
       return new ArrayList<>();
     } catch (final TiKVException e) {
       // TODO: any elegant way to re-split the ranges if fails?
@@ -770,7 +747,7 @@ public class RawKVClient implements AutoCloseable {
         backOffer, batch.getKeys(), RAW_BATCH_GET_SIZE, MAX_RAW_BATCH_LIMIT, clientBuilder);
   }
 
-  private void doSendBatchDelete(BackOffer backOffer, List<ByteString> keys, boolean atomic) {
+  private void doSendBatchDelete(BackOffer backOffer, List<ByteString> keys) {
     ExecutorCompletionService<List<Batch>> completionService =
         new ExecutorCompletionService<>(batchDeleteThreadPool);
 
@@ -784,17 +761,16 @@ public class RawKVClient implements AutoCloseable {
       List<Batch> task = taskQueue.poll();
       for (Batch batch : task) {
         completionService.submit(
-            () -> doSendBatchDeleteInBatchesWithRetry(batch.getBackOffer(), batch, atomic));
+            () -> doSendBatchDeleteInBatchesWithRetry(batch.getBackOffer(), batch));
       }
       getTasks(completionService, taskQueue, task, BackOffer.RAWKV_MAX_BACKOFF);
     }
   }
 
-  private List<Batch> doSendBatchDeleteInBatchesWithRetry(
-      BackOffer backOffer, Batch batch, boolean atomic) {
+  private List<Batch> doSendBatchDeleteInBatchesWithRetry(BackOffer backOffer, Batch batch) {
     RegionStoreClient client = clientBuilder.build(batch.getRegion());
     try {
-      client.rawBatchDelete(backOffer, batch.getKeys(), atomic);
+      client.rawBatchDelete(backOffer, batch.getKeys(), atomicForCAS);
       return new ArrayList<>();
     } catch (final TiKVException e) {
       backOffer.doBackOff(BackOffFunction.BackOffFuncType.BoRegionMiss, e);

--- a/src/main/java/org/tikv/raw/RawKVClient.java
+++ b/src/main/java/org/tikv/raw/RawKVClient.java
@@ -198,7 +198,7 @@ public class RawKVClient implements AutoCloseable {
       throws RawCASConflictException {
     if (!atomicForCAS) {
       throw new IllegalArgumentException(
-          "To use Compare And Swap, please enable the config tikv.enable_atomic_for_cas.");
+          "To use compareAndSet or putIfAbsent, please enable the config tikv.enable_atomic_for_cas.");
     }
 
     String label = "client_raw_compare_and_set";

--- a/src/test/java/org/tikv/raw/CASTest.java
+++ b/src/test/java/org/tikv/raw/CASTest.java
@@ -1,0 +1,85 @@
+package org.tikv.raw;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import com.google.protobuf.ByteString;
+import java.util.Optional;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.tikv.common.TiConfiguration;
+import org.tikv.common.TiSession;
+import org.tikv.common.exception.RawCASConflictException;
+
+public class CASTest {
+  private RawKVClient client;
+  private boolean initialized;
+  private static final Logger logger = LoggerFactory.getLogger(RawKVClientTest.class);
+  private TiSession session;
+
+  @Before
+  public void setup() {
+    try {
+      TiConfiguration conf = TiConfiguration.createRawDefault();
+      conf.setEnableAtomicForCAS(true);
+      session = TiSession.create(conf);
+      initialized = false;
+      if (client == null) {
+        client = session.createRawClient();
+      }
+      initialized = true;
+    } catch (Exception e) {
+      logger.warn(
+          "Cannot initialize raw client, please check whether TiKV is running. Test skipped.", e);
+    }
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if (session != null) {
+      session.close();
+    }
+  }
+
+  @Test
+  public void rawCASTest() {
+    if (!initialized) return;
+    ByteString key = ByteString.copyFromUtf8("key_atomic");
+    ByteString value = ByteString.copyFromUtf8("value");
+    ByteString value2 = ByteString.copyFromUtf8("value2");
+    client.delete(key);
+    client.compareAndSet(key, Optional.empty(), value);
+    Assert.assertEquals(value, client.get(key).get());
+    try {
+      client.compareAndSet(key, Optional.empty(), value2);
+      Assert.fail("compareAndSet should fail.");
+    } catch (RawCASConflictException err) {
+      Assert.assertEquals(value, err.getPrevValue().get());
+    }
+  }
+
+  @Test
+  public void rawPutIfAbsentTest() {
+    if (!initialized) return;
+    long ttl = 10;
+    ByteString key = ByteString.copyFromUtf8("key_atomic");
+    ByteString value = ByteString.copyFromUtf8("value");
+    ByteString value2 = ByteString.copyFromUtf8("value2");
+    client.delete(key);
+    Optional<ByteString> res1 = client.putIfAbsent(key, value, ttl);
+    assertFalse(res1.isPresent());
+    Optional<ByteString> res2 = client.putIfAbsent(key, value2, ttl);
+    assertEquals(res2.get(), value);
+    try {
+      Thread.sleep(ttl * 1000);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+    Optional<ByteString> res3 = client.putIfAbsent(key, value, ttl);
+    assertFalse(res3.isPresent());
+  }
+}


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
close https://github.com/tikv/client-java/issues/212

Currently, users should pass the parameter `atomic`  to funcions like`put`、`batchPut`、`delete`、`batchDelete` when using `CAS` in `RawKVClient`.


### What is changed and how it works?
Add a config `tikv.enable_atomic_for_cas` replacing the `atomic` parameter on each write function like `put`、`delete`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to be included in the release note
