### PR TITLE
fix closeAwaitTermination UT

### DIFF
--- a/src/test/java/org/tikv/common/TiSessionTest.java
+++ b/src/test/java/org/tikv/common/TiSessionTest.java
@@ -63,7 +63,6 @@ public class TiSessionTest {
       session.close();
       Thread.sleep(1000);
       assertNotNull(interruptedException.get());
-      assertTrue(System.currentTimeMillis() - startMS < 2000);
     } else {
       session.closeAwaitTermination(timeoutMS);
       assertNotNull(interruptedException.get());


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

The UT of `session.closeAwaitTermination` is not stable, because it depends on `time`.

### What is changed and how it works?
remove the `time` from the UT.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to be included in the release note
