### PR TITLE
update pd get member timeout from 2s to 10s

### DIFF
--- a/src/main/java/org/tikv/common/ConfigUtils.java
+++ b/src/main/java/org/tikv/common/ConfigUtils.java
@@ -23,7 +23,8 @@ public class ConfigUtils {
   public static final String TIKV_GRPC_TIMEOUT = "tikv.grpc.timeout_in_ms";
   public static final String TIKV_GRPC_INGEST_TIMEOUT = "tikv.grpc.ingest_timeout_in_ms";
   public static final String TIKV_GRPC_FORWARD_TIMEOUT = "tikv.grpc.forward_timeout_in_ms";
-  public static final String TIKV_PD_GET_MEMBER_TIMEOUT = "tikv.grpc.pd_get_member_timeout_in_ms";
+  public static final String TIKV_PD_FIRST_GET_MEMBER_TIMEOUT =
+      "tikv.grpc.pd_first_get_member_timeout_in_ms";
   public static final String TIKV_GRPC_SCAN_TIMEOUT = "tikv.grpc.scan_timeout_in_ms";
   public static final String TIKV_GRPC_SCAN_BATCH_SIZE = "tikv.grpc.scan_batch_size";
   public static final String TIKV_GRPC_MAX_FRAME_SIZE = "tikv.grpc.max_frame_size";
@@ -70,7 +71,7 @@ public class ConfigUtils {
   public static final String DEF_TIMEOUT = "200ms";
   public static final String DEF_TIKV_GRPC_INGEST_TIMEOUT = "200s";
   public static final String DEF_FORWARD_TIMEOUT = "300ms";
-  public static final String DEF_TIKV_PD_GET_MEMBER_TIMEOUT = "10000ms";
+  public static final String DEF_TIKV_PD_FIRST_GET_MEMBER_TIMEOUT = "10000ms";
   public static final String DEF_SCAN_TIMEOUT = "20s";
   public static final int DEF_CHECK_HEALTH_TIMEOUT = 100;
   public static final int DEF_HEALTH_CHECK_PERIOD_DURATION = 300;

--- a/src/main/java/org/tikv/common/ConfigUtils.java
+++ b/src/main/java/org/tikv/common/ConfigUtils.java
@@ -23,6 +23,7 @@ public class ConfigUtils {
   public static final String TIKV_GRPC_TIMEOUT = "tikv.grpc.timeout_in_ms";
   public static final String TIKV_GRPC_INGEST_TIMEOUT = "tikv.grpc.ingest_timeout_in_ms";
   public static final String TIKV_GRPC_FORWARD_TIMEOUT = "tikv.grpc.forward_timeout_in_ms";
+  public static final String TIKV_PD_GET_MEMBER_TIMEOUT = "tikv.grpc.pd_get_member_timeout_in_ms";
   public static final String TIKV_GRPC_SCAN_TIMEOUT = "tikv.grpc.scan_timeout_in_ms";
   public static final String TIKV_GRPC_SCAN_BATCH_SIZE = "tikv.grpc.scan_batch_size";
   public static final String TIKV_GRPC_MAX_FRAME_SIZE = "tikv.grpc.max_frame_size";
@@ -69,6 +70,7 @@ public class ConfigUtils {
   public static final String DEF_TIMEOUT = "200ms";
   public static final String DEF_TIKV_GRPC_INGEST_TIMEOUT = "200s";
   public static final String DEF_FORWARD_TIMEOUT = "300ms";
+  public static final String DEF_TIKV_PD_GET_MEMBER_TIMEOUT = "10000ms";
   public static final String DEF_SCAN_TIMEOUT = "20s";
   public static final int DEF_CHECK_HEALTH_TIMEOUT = 100;
   public static final int DEF_HEALTH_CHECK_PERIOD_DURATION = 300;

--- a/src/main/java/org/tikv/common/PDClient.java
+++ b/src/main/java/org/tikv/common/PDClient.java
@@ -575,7 +575,7 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDStub>
             .orElseGet(() -> new DefaultHostMapping(this.etcdClient, conf.getNetworkMappingName()));
     // The first request may cost too much latency
     long originTimeout = this.timeout;
-    this.timeout = conf.getPdGetMemberTimeout();
+    this.timeout = conf.getPdFirstGetMemberTimeout();
     for (URI u : pdAddrs) {
       resp = getMembers(u);
       if (resp != null) {

--- a/src/main/java/org/tikv/common/PDClient.java
+++ b/src/main/java/org/tikv/common/PDClient.java
@@ -337,7 +337,7 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDStub>
       }
       return resp;
     } catch (Exception e) {
-      logger.debug("failed to get member from pd server.", e);
+      logger.warn("failed to get member from pd server.", e);
     }
     return null;
   }
@@ -575,7 +575,7 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDStub>
             .orElseGet(() -> new DefaultHostMapping(this.etcdClient, conf.getNetworkMappingName()));
     // The first request may cost too much latency
     long originTimeout = this.timeout;
-    this.timeout = 2000;
+    this.timeout = conf.getPdGetMemberTimeout();
     for (URI u : pdAddrs) {
       resp = getMembers(u);
       if (resp != null) {

--- a/src/main/java/org/tikv/common/TiConfiguration.java
+++ b/src/main/java/org/tikv/common/TiConfiguration.java
@@ -56,7 +56,7 @@ public class TiConfiguration implements Serializable {
     setIfMissing(TIKV_GRPC_TIMEOUT, DEF_TIMEOUT);
     setIfMissing(TIKV_GRPC_INGEST_TIMEOUT, DEF_TIKV_GRPC_INGEST_TIMEOUT);
     setIfMissing(TIKV_GRPC_FORWARD_TIMEOUT, DEF_FORWARD_TIMEOUT);
-    setIfMissing(TIKV_PD_GET_MEMBER_TIMEOUT, DEF_TIKV_PD_GET_MEMBER_TIMEOUT);
+    setIfMissing(TIKV_PD_FIRST_GET_MEMBER_TIMEOUT, DEF_TIKV_PD_FIRST_GET_MEMBER_TIMEOUT);
     setIfMissing(TIKV_GRPC_SCAN_TIMEOUT, DEF_SCAN_TIMEOUT);
     setIfMissing(TIKV_GRPC_SCAN_BATCH_SIZE, DEF_SCAN_BATCH_SIZE);
     setIfMissing(TIKV_GRPC_MAX_FRAME_SIZE, DEF_MAX_FRAME_SIZE);
@@ -247,7 +247,7 @@ public class TiConfiguration implements Serializable {
   private long timeout = getTimeAsMs(TIKV_GRPC_TIMEOUT);
   private long ingestTimeout = getTimeAsMs(TIKV_GRPC_INGEST_TIMEOUT);
   private long forwardTimeout = getTimeAsMs(TIKV_GRPC_FORWARD_TIMEOUT);
-  private long pdGetMemberTimeout = getTimeAsMs(TIKV_PD_GET_MEMBER_TIMEOUT);
+  private long pdFirstGetMemberTimeout = getTimeAsMs(TIKV_PD_FIRST_GET_MEMBER_TIMEOUT);
   private long scanTimeout = getTimeAsMs(TIKV_GRPC_SCAN_TIMEOUT);
   private int maxFrameSize = getInt(TIKV_GRPC_MAX_FRAME_SIZE);
   private List<URI> pdAddrs = getPdAddrs(TIKV_PD_ADDRESSES);
@@ -373,12 +373,12 @@ public class TiConfiguration implements Serializable {
     return this;
   }
 
-  public long getPdGetMemberTimeout() {
-    return pdGetMemberTimeout;
+  public long getPdFirstGetMemberTimeout() {
+    return pdFirstGetMemberTimeout;
   }
 
-  public void setPdGetMemberTimeout(long pdGetMemberTimeout) {
-    this.pdGetMemberTimeout = pdGetMemberTimeout;
+  public void setPdFirstGetMemberTimeout(long pdFirstGetMemberTimeout) {
+    this.pdFirstGetMemberTimeout = pdFirstGetMemberTimeout;
   }
 
   public long getScanTimeout() {

--- a/src/main/java/org/tikv/common/TiConfiguration.java
+++ b/src/main/java/org/tikv/common/TiConfiguration.java
@@ -56,6 +56,7 @@ public class TiConfiguration implements Serializable {
     setIfMissing(TIKV_GRPC_TIMEOUT, DEF_TIMEOUT);
     setIfMissing(TIKV_GRPC_INGEST_TIMEOUT, DEF_TIKV_GRPC_INGEST_TIMEOUT);
     setIfMissing(TIKV_GRPC_FORWARD_TIMEOUT, DEF_FORWARD_TIMEOUT);
+    setIfMissing(TIKV_PD_GET_MEMBER_TIMEOUT, DEF_TIKV_PD_GET_MEMBER_TIMEOUT);
     setIfMissing(TIKV_GRPC_SCAN_TIMEOUT, DEF_SCAN_TIMEOUT);
     setIfMissing(TIKV_GRPC_SCAN_BATCH_SIZE, DEF_SCAN_BATCH_SIZE);
     setIfMissing(TIKV_GRPC_MAX_FRAME_SIZE, DEF_MAX_FRAME_SIZE);
@@ -246,6 +247,7 @@ public class TiConfiguration implements Serializable {
   private long timeout = getTimeAsMs(TIKV_GRPC_TIMEOUT);
   private long ingestTimeout = getTimeAsMs(TIKV_GRPC_INGEST_TIMEOUT);
   private long forwardTimeout = getTimeAsMs(TIKV_GRPC_FORWARD_TIMEOUT);
+  private long pdGetMemberTimeout = getTimeAsMs(TIKV_PD_GET_MEMBER_TIMEOUT);
   private long scanTimeout = getTimeAsMs(TIKV_GRPC_SCAN_TIMEOUT);
   private int maxFrameSize = getInt(TIKV_GRPC_MAX_FRAME_SIZE);
   private List<URI> pdAddrs = getPdAddrs(TIKV_PD_ADDRESSES);
@@ -369,6 +371,14 @@ public class TiConfiguration implements Serializable {
   public TiConfiguration setForwardTimeout(long timeout) {
     this.forwardTimeout = timeout;
     return this;
+  }
+
+  public long getPdGetMemberTimeout() {
+    return pdGetMemberTimeout;
+  }
+
+  public void setPdGetMemberTimeout(long pdGetMemberTimeout) {
+    this.pdGetMemberTimeout = pdGetMemberTimeout;
   }
 
   public long getScanTimeout() {


### PR DESCRIPTION
Signed-off-by: marsishandsome <marsishandsome@gmail.com>

### What problem does this PR solve? <!--add issue link with summary if exists-->
close https://github.com/tikv/client-java/issues/260

Failed to init client for PD cluster with 240 clients

### What is changed and how it works?

update pd get member timeout from 2s to 10s

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to be included in the release note
