### PR TITLE
let class Key implmemnts Serializable

### DIFF
--- a/src/main/java/org/tikv/common/key/Key.java
+++ b/src/main/java/org/tikv/common/key/Key.java
@@ -20,13 +20,14 @@ import static org.tikv.common.codec.KeyUtils.formatBytes;
 
 import com.google.common.primitives.Bytes;
 import com.google.protobuf.ByteString;
+import java.io.Serializable;
 import java.util.Arrays;
 import javax.annotation.Nonnull;
 import org.tikv.common.codec.CodecDataOutput;
 import org.tikv.common.types.DataType;
 import org.tikv.common.util.FastByteComparisons;
 
-public class Key implements Comparable<Key> {
+public class Key implements Comparable<Key>, Serializable {
   public static final Key EMPTY = createEmpty();
   public static final Key NULL = createNull();
   public static final Key MIN = createTypelessMin();


### PR DESCRIPTION
Signed-off-by: marsishandsome <marsishandsome@gmail.com>

### What problem does this PR solve? <!--add issue link with summary if exists-->

We create a additional class 
https://github.com/tikv/migration/blob/main/online-bulk-load/src/main/scala/org/tikv/bulkload/SerializableKey.scala, because Key does not implmemnt Serializable.

### What is changed and how it works?
let class Key implmemnts Serializable, so that SerializableKey is no more needed.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to be included in the release note
