### PR TITLE
PDClient: Add function to call pause checker API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,6 +197,11 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.5.13</version>
+        </dependency>
+        <dependency>
             <groupId>io.prometheus</groupId>
             <artifactId>simpleclient</artifactId>
             <version>0.10.0</version>

--- a/src/main/java/org/tikv/common/PDChecker.java
+++ b/src/main/java/org/tikv/common/PDChecker.java
@@ -1,0 +1,31 @@
+package org.tikv.common;
+
+public enum PDChecker {
+  Learner,
+  Replica,
+  Rule,
+  Split,
+  Merge,
+  JointState,
+  Priority;
+
+  public String apiName() {
+    switch (this) {
+      case Learner:
+        return "learner";
+      case Replica:
+        return "replica";
+      case Rule:
+        return "rule";
+      case Split:
+        return "split";
+      case Merge:
+        return "merge";
+      case JointState:
+        return "joint-state";
+      case Priority:
+        return "priority";
+    }
+    throw new IllegalArgumentException();
+  }
+}

--- a/src/main/java/org/tikv/common/PDClient.java
+++ b/src/main/java/org/tikv/common/PDClient.java
@@ -100,15 +100,15 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDStub>
     implements ReadOnlyPDClient {
   private static final String TIFLASH_TABLE_SYNC_PROGRESS_PATH = "/tiflash/table/sync";
   private static final long MIN_TRY_UPDATE_DURATION = 50;
-  private static final int PAUSE_CHECKER_TIMEOUT = 600;
-  private static final int KEEP_CHECKER_PAUSE_PERIOD = PAUSE_CHECKER_TIMEOUT / 5;
+  private static final int PAUSE_CHECKER_TIMEOUT = 300; // in seconds
+  private static final int KEEP_CHECKER_PAUSE_PERIOD = PAUSE_CHECKER_TIMEOUT / 5; // in seconds
   private final Logger logger = LoggerFactory.getLogger(PDClient.class);
   private RequestHeader header;
   private TsoRequest tsoReq;
   private volatile PDClientWrapper pdClientWrapper;
   private ScheduledExecutorService service;
   private ScheduledExecutorService tiflashReplicaService;
-  private HashMap<PDChecker, ScheduledExecutorService> pauseCheckerService;
+  private final HashMap<PDChecker, ScheduledExecutorService> pauseCheckerService = new HashMap<>();
   private List<URI> pdAddrs;
   private Client etcdClient;
   private ConcurrentMap<Long, Double> tiflashReplicaMap;

--- a/src/main/java/org/tikv/common/PDClient.java
+++ b/src/main/java/org/tikv/common/PDClient.java
@@ -165,20 +165,20 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDStub>
                   .setNameFormat(String.format("PDClient-pause-%s-pool-%%d", checker.name()))
                   .setDaemon(true)
                   .build());
+      newService
+          .scheduleAtFixedRate(
+              () -> pauseChecker(checker, PAUSE_CHECKER_TIMEOUT),
+              0,
+              KEEP_CHECKER_PAUSE_PERIOD,
+              TimeUnit.SECONDS);
       this.pauseCheckerService.put(checker, newService);
     }
-    this.pauseCheckerService
-        .get(checker)
-        .scheduleAtFixedRate(
-            () -> pauseChecker(checker, PAUSE_CHECKER_TIMEOUT),
-            0,
-            KEEP_CHECKER_PAUSE_PERIOD,
-            TimeUnit.SECONDS);
   }
 
   public void stopKeepPauseChecker(PDChecker checker) {
     if (this.pauseCheckerService.containsKey(checker)) {
       this.pauseCheckerService.get(checker).shutdown();
+      this.pauseCheckerService.remove(checker);
     }
   }
 

--- a/src/main/java/org/tikv/common/PDClient.java
+++ b/src/main/java/org/tikv/common/PDClient.java
@@ -157,7 +157,7 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDStub>
     return new TiTimestamp(timestamp.getPhysical(), timestamp.getLogical());
   }
 
-  public void keepPauseChecker(PDChecker checker) {
+  public synchronized void keepPauseChecker(PDChecker checker) {
     if (!this.pauseCheckerService.containsKey(checker)) {
       ScheduledExecutorService newService =
           Executors.newSingleThreadScheduledExecutor(
@@ -174,7 +174,7 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDStub>
     }
   }
 
-  public void stopKeepPauseChecker(PDChecker checker) {
+  public synchronized void stopKeepPauseChecker(PDChecker checker) {
     if (this.pauseCheckerService.containsKey(checker)) {
       this.pauseCheckerService.get(checker).shutdown();
       this.pauseCheckerService.remove(checker);

--- a/src/main/java/org/tikv/common/PDClient.java
+++ b/src/main/java/org/tikv/common/PDClient.java
@@ -165,12 +165,11 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDStub>
                   .setNameFormat(String.format("PDClient-pause-%s-pool-%%d", checker.name()))
                   .setDaemon(true)
                   .build());
-      newService
-          .scheduleAtFixedRate(
-              () -> pauseChecker(checker, PAUSE_CHECKER_TIMEOUT),
-              0,
-              KEEP_CHECKER_PAUSE_PERIOD,
-              TimeUnit.SECONDS);
+      newService.scheduleAtFixedRate(
+          () -> pauseChecker(checker, PAUSE_CHECKER_TIMEOUT),
+          0,
+          KEEP_CHECKER_PAUSE_PERIOD,
+          TimeUnit.SECONDS);
       this.pauseCheckerService.put(checker, newService);
     }
   }

--- a/src/test/java/org/tikv/common/PDClientIntegrationTest.java
+++ b/src/test/java/org/tikv/common/PDClientIntegrationTest.java
@@ -1,11 +1,11 @@
 package org.tikv.common;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 public class PDClientIntegrationTest {
   private TiSession session;

--- a/src/test/java/org/tikv/common/PDClientIntegrationTest.java
+++ b/src/test/java/org/tikv/common/PDClientIntegrationTest.java
@@ -1,0 +1,44 @@
+package org.tikv.common;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class PDClientIntegrationTest {
+  private TiSession session;
+
+  @Before
+  public void setup() {
+    TiConfiguration conf = TiConfiguration.createRawDefault();
+    conf.setTest(true);
+    session = TiSession.create(conf);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if (session != null) {
+      session.close();
+    }
+  }
+
+  @Test
+  public void testPauseCheck() throws Exception {
+    try (PDClient client = session.getPDClient()) {
+      PDChecker checker = PDChecker.Merge;
+      for (int i = 0; i < 2; i++) {
+        client.keepPauseChecker(checker);
+        Thread.sleep(1000);
+        assertTrue(client.isCheckerPaused(checker));
+
+        client.stopKeepPauseChecker(checker);
+        Thread.sleep(1000);
+
+        client.resumeChecker(checker);
+        assertFalse(client.isCheckerPaused(checker));
+      }
+    }
+  }
+}

--- a/src/test/java/org/tikv/common/PDClientTest.java
+++ b/src/test/java/org/tikv/common/PDClientTest.java
@@ -71,9 +71,12 @@ public class PDClientTest extends PDMockServerTest {
   @Test
   public void testPauseCheck() throws Exception {
     try (PDClient client = session.getPDClient()) {
-      client.keepPauseChecker(PDChecker.Merge);
-      Thread.sleep(6000);
-      client.stopKeepPauseChecker(PDChecker.Merge);
+      PDChecker checker = PDChecker.Merge;
+      client.keepPauseChecker(checker);
+      Thread.sleep(1000);
+      client.stopKeepPauseChecker(checker);
+      Thread.sleep(1000);
+      client.resumeChecker(checker);
     }
   }
 

--- a/src/test/java/org/tikv/common/PDClientTest.java
+++ b/src/test/java/org/tikv/common/PDClientTest.java
@@ -72,15 +72,17 @@ public class PDClientTest extends PDMockServerTest {
   public void testPauseCheck() throws Exception {
     try (PDClient client = session.getPDClient()) {
       PDChecker checker = PDChecker.Merge;
-      client.keepPauseChecker(checker);
-      Thread.sleep(1000);
-      assertTrue(client.isCheckerPaused(checker));
-
-      client.stopKeepPauseChecker(checker);
-      Thread.sleep(1000);
-
-      client.resumeChecker(checker);
-      assertFalse(client.isCheckerPaused(checker));
+      for(int i = 0; i < 2; i ++) {
+        client.keepPauseChecker(checker);
+        Thread.sleep(1000);
+        assertTrue(client.isCheckerPaused(checker));
+  
+        client.stopKeepPauseChecker(checker);
+        Thread.sleep(1000);
+  
+        client.resumeChecker(checker);
+        assertFalse(client.isCheckerPaused(checker));
+      }
     }
   }
 

--- a/src/test/java/org/tikv/common/PDClientTest.java
+++ b/src/test/java/org/tikv/common/PDClientTest.java
@@ -72,14 +72,14 @@ public class PDClientTest extends PDMockServerTest {
   public void testPauseCheck() throws Exception {
     try (PDClient client = session.getPDClient()) {
       PDChecker checker = PDChecker.Merge;
-      for(int i = 0; i < 2; i ++) {
+      for (int i = 0; i < 2; i++) {
         client.keepPauseChecker(checker);
         Thread.sleep(1000);
         assertTrue(client.isCheckerPaused(checker));
-  
+
         client.stopKeepPauseChecker(checker);
         Thread.sleep(1000);
-  
+
         client.resumeChecker(checker);
         assertFalse(client.isCheckerPaused(checker));
       }

--- a/src/test/java/org/tikv/common/PDClientTest.java
+++ b/src/test/java/org/tikv/common/PDClientTest.java
@@ -16,7 +16,6 @@
 package org.tikv.common;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.tikv.common.GrpcUtils.encodeKey;
@@ -75,24 +74,6 @@ public class PDClientTest extends PDMockServerTest {
       TiTimestamp ts = client.getTimestamp(defaultBackOff());
       // Test pdServer is set to generate physical == logical + 1
       assertEquals(ts.getPhysical(), ts.getLogical() + 1);
-    }
-  }
-
-  @Test
-  public void testPauseCheck() throws Exception {
-    try (PDClient client = session.getPDClient()) {
-      PDChecker checker = PDChecker.Merge;
-      for (int i = 0; i < 2; i++) {
-        client.keepPauseChecker(checker);
-        Thread.sleep(1000);
-        assertTrue(client.isCheckerPaused(checker));
-
-        client.stopKeepPauseChecker(checker);
-        Thread.sleep(1000);
-
-        client.resumeChecker(checker);
-        assertFalse(client.isCheckerPaused(checker));
-      }
     }
   }
 

--- a/src/test/java/org/tikv/common/PDClientTest.java
+++ b/src/test/java/org/tikv/common/PDClientTest.java
@@ -74,9 +74,13 @@ public class PDClientTest extends PDMockServerTest {
       PDChecker checker = PDChecker.Merge;
       client.keepPauseChecker(checker);
       Thread.sleep(1000);
+      assertTrue(client.isCheckerPaused(checker));
+
       client.stopKeepPauseChecker(checker);
       Thread.sleep(1000);
+
       client.resumeChecker(checker);
+      assertFalse(client.isCheckerPaused(checker));
     }
   }
 

--- a/src/test/java/org/tikv/common/PDClientTest.java
+++ b/src/test/java/org/tikv/common/PDClientTest.java
@@ -69,6 +69,15 @@ public class PDClientTest extends PDMockServerTest {
   }
 
   @Test
+  public void testPauseCheck() throws Exception {
+    try (PDClient client = session.getPDClient()) {
+      client.keepPauseChecker(PDChecker.Merge);
+      Thread.sleep(6000);
+      client.stopKeepPauseChecker(PDChecker.Merge);
+    }
+  }
+
+  @Test
   public void testGetRegionByKey() throws Exception {
     byte[] startKey = new byte[] {1, 0, 2, 4};
     byte[] endKey = new byte[] {1, 0, 2, 5};


### PR DESCRIPTION
Signed-off-by: Peng Guanwen <pg999w@outlook.com>

### What problem does this PR solve? <!--add issue link with summary if exists-->

https://github.com/tikv/client-java/issues/268 needs to call pause checker in Java client. This PR adds the function.

### What is changed and how it works?
Added functions:

- `PDClient.keepPauseChecker`
- `PDClient.stopKeepPauseChecker`
- `PDClient.resumeChecker`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

 - Has exported function/method change

Related changes

 - Need to be included in the release note
