### PR TITLE
support APIVersion in BackupMeta

### DIFF
--- a/scripts/proto.sh
+++ b/scripts/proto.sh
@@ -14,7 +14,7 @@
 #   limitations under the License.
 #
 
-kvproto_hash=465fa4c7b42e644d5aacaf79d06c75733dc12eb3
+kvproto_hash=d62ddcee4ccd95f19f3ffa89c2832f2fb81030ca
 raft_rs_hash=b9891b673573fad77ebcf9bbe0969cf945841926
 tipb_hash=c4d518eb1d60c21f05b028b36729e64610346dac
 

--- a/src/main/java/org/tikv/br/BackupDecoder.java
+++ b/src/main/java/org/tikv/br/BackupDecoder.java
@@ -41,11 +41,13 @@ public class BackupDecoder implements Serializable {
   }
 
   private KVDecoder initKVDecoder() throws SSTDecodeException {
-    // Currently only v1 is supported.
-    // V2 will be added after https://github.com/tikv/tikv/issues/10938.
     if (backupMeta.getIsRawKv()) {
-      // TODO: ttl_enable should be witten to BackupMeta
-      return new RawKVDecoderV1(ttlEnabled);
+      if ("V1".equals(backupMeta.getApiVersion().name())) {
+        return new RawKVDecoderV1(ttlEnabled);
+      } else {
+        throw new SSTDecodeException(
+            "does not support decode APIVersion " + backupMeta.getApiVersion().name());
+      }
     } else {
       throw new SSTDecodeException("TxnKV is not supported yet!");
     }


### PR DESCRIPTION
Signed-off-by: marsishandsome <marsishandsome@gmail.com>

### What problem does this PR solve? <!--add issue link with summary if exists-->

issue: https://github.com/pingcap/tidb/issues/28823

when decoding SST files generated by `br backup`, we should know:
- `api version`

the decoding metho depends on it.

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to be included in the release note
