### PR TITLE
pd backoff use tikv.rawkv.default_backoff_in_ms

### DIFF
--- a/src/main/java/org/tikv/common/region/RegionManager.java
+++ b/src/main/java/org/tikv/common/region/RegionManager.java
@@ -90,7 +90,7 @@ public class RegionManager {
   }
 
   public TiRegion getRegionByKey(ByteString key) {
-    return getRegionByKey(key, ConcreteBackOffer.newGetBackOff());
+    return getRegionByKey(key, defaultBackOff());
   }
 
   public TiRegion getRegionByKey(ByteString key, BackOffer backOffer) {
@@ -118,7 +118,7 @@ public class RegionManager {
   // Consider region A, B. After merge of (A, B) -> A, region ID B does not exist.
   // This request is unrecoverable.
   public TiRegion getRegionById(long regionId) {
-    BackOffer backOffer = ConcreteBackOffer.newGetBackOff();
+    BackOffer backOffer = defaultBackOff();
     TiRegion region = cache.getRegionById(regionId);
     if (region == null) {
       Pair<Metapb.Region, Metapb.Peer> regionAndLeader =
@@ -138,7 +138,7 @@ public class RegionManager {
   }
 
   public Pair<TiRegion, TiStore> getRegionStorePairByKey(ByteString key, TiStoreType storeType) {
-    return getRegionStorePairByKey(key, storeType, ConcreteBackOffer.newGetBackOff());
+    return getRegionStorePairByKey(key, storeType, defaultBackOff());
   }
 
   public Pair<TiRegion, TiStore> getRegionStorePairByKey(
@@ -210,7 +210,7 @@ public class RegionManager {
   }
 
   public TiStore getStoreById(long id) {
-    return getStoreById(id, ConcreteBackOffer.newGetBackOff());
+    return getStoreById(id, defaultBackOff());
   }
 
   public void onRegionStale(TiRegion region) {
@@ -257,5 +257,9 @@ public class RegionManager {
 
   public void invalidateRegion(TiRegion region) {
     cache.invalidateRegion(region);
+  }
+
+  private BackOffer defaultBackOff() {
+    return ConcreteBackOffer.newCustomBackOff(conf.getRawKVDefaultBackoffInMS());
   }
 }

--- a/src/main/java/org/tikv/common/region/RegionStoreClient.java
+++ b/src/main/java/org/tikv/common/region/RegionStoreClient.java
@@ -1284,19 +1284,39 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
       return build(key, TiStoreType.TiKV);
     }
 
+    public synchronized RegionStoreClient build(ByteString key, BackOffer backOffer)
+        throws GrpcException {
+      return build(key, TiStoreType.TiKV, backOffer);
+    }
+
     public synchronized RegionStoreClient build(ByteString key, TiStoreType storeType)
         throws GrpcException {
-      Pair<TiRegion, TiStore> pair = regionManager.getRegionStorePairByKey(key, storeType);
+      return build(key, storeType, defaultBackOff());
+    }
+
+    public synchronized RegionStoreClient build(
+        ByteString key, TiStoreType storeType, BackOffer backOffer) throws GrpcException {
+      Pair<TiRegion, TiStore> pair =
+          regionManager.getRegionStorePairByKey(key, storeType, backOffer);
       return build(pair.first, pair.second, storeType);
     }
 
     public synchronized RegionStoreClient build(TiRegion region) throws GrpcException {
-      TiStore store = regionManager.getStoreById(region.getLeader().getStoreId());
+      return build(region, defaultBackOff());
+    }
+
+    public synchronized RegionStoreClient build(TiRegion region, BackOffer backOffer)
+        throws GrpcException {
+      TiStore store = regionManager.getStoreById(region.getLeader().getStoreId(), backOffer);
       return build(region, store, TiStoreType.TiKV);
     }
 
     public RegionManager getRegionManager() {
       return regionManager;
+    }
+
+    private BackOffer defaultBackOff() {
+      return ConcreteBackOffer.newCustomBackOff(conf.getRawKVDefaultBackoffInMS());
     }
   }
 }

--- a/src/main/java/org/tikv/common/util/BackOffer.java
+++ b/src/main/java/org/tikv/common/util/BackOffer.java
@@ -20,22 +20,12 @@ package org.tikv.common.util;
 public interface BackOffer {
   // Back off types.
   int seconds = 1000;
-  int COP_BUILD_TASK_MAX_BACKOFF = 5 * seconds;
   int TSO_MAX_BACKOFF = 5 * seconds;
   int SCANNER_NEXT_MAX_BACKOFF = 40 * seconds;
   int BATCH_GET_MAX_BACKOFF = 40 * seconds;
   int COP_NEXT_MAX_BACKOFF = 40 * seconds;
   int GET_MAX_BACKOFF = 40 * seconds;
-  int PREWRITE_MAX_BACKOFF = 20 * seconds;
-  int CLEANUP_MAX_BACKOFF = 20 * seconds;
-  int GC_ONE_REGION_MAX_BACKOFF = 20 * seconds;
-  int GC_RESOLVE_LOCK_MAX_BACKOFF = 100 * seconds;
-  int GC_DELETE_RANGE_MAX_BACKOFF = 100 * seconds;
-
   int RAWKV_MAX_BACKOFF = 20 * seconds;
-
-  int SPLIT_REGION_BACKOFF = 20 * seconds;
-  int BATCH_COMMIT_BACKOFF = 10 * seconds;
   int PD_INFO_BACKOFF = 5 * seconds;
 
   /**

--- a/src/main/java/org/tikv/raw/RawKVClient.java
+++ b/src/main/java/org/tikv/raw/RawKVClient.java
@@ -132,7 +132,7 @@ public class RawKVClient implements AutoCloseable {
     try {
       BackOffer backOffer = defaultBackOff();
       while (true) {
-        RegionStoreClient client = clientBuilder.build(key);
+        RegionStoreClient client = clientBuilder.build(key, backOffer);
         try {
           client.rawPut(backOffer, key, value, ttl, atomic);
           RAW_REQUEST_SUCCESS.labels(label).inc();
@@ -176,7 +176,7 @@ public class RawKVClient implements AutoCloseable {
     try {
       BackOffer backOffer = defaultBackOff();
       while (true) {
-        RegionStoreClient client = clientBuilder.build(key);
+        RegionStoreClient client = clientBuilder.build(key, backOffer);
         try {
           ByteString result = client.rawPutIfAbsent(backOffer, key, value, ttl);
           RAW_REQUEST_SUCCESS.labels(label).inc();
@@ -257,7 +257,7 @@ public class RawKVClient implements AutoCloseable {
     try {
       BackOffer backOffer = defaultBackOff();
       while (true) {
-        RegionStoreClient client = clientBuilder.build(key);
+        RegionStoreClient client = clientBuilder.build(key, backOffer);
         try {
           ByteString result = client.rawGet(defaultBackOff(), key);
           RAW_REQUEST_SUCCESS.labels(label).inc();
@@ -343,7 +343,7 @@ public class RawKVClient implements AutoCloseable {
     try {
       BackOffer backOffer = defaultBackOff();
       while (true) {
-        RegionStoreClient client = clientBuilder.build(key);
+        RegionStoreClient client = clientBuilder.build(key, backOffer);
         try {
           Long result = client.rawGetKeyTTL(defaultBackOff(), key);
           RAW_REQUEST_SUCCESS.labels(label).inc();
@@ -561,7 +561,7 @@ public class RawKVClient implements AutoCloseable {
     try {
       BackOffer backOffer = defaultBackOff();
       while (true) {
-        RegionStoreClient client = clientBuilder.build(key);
+        RegionStoreClient client = clientBuilder.build(key, backOffer);
         try {
           client.rawDelete(defaultBackOff(), key, atomic);
           RAW_REQUEST_SUCCESS.labels(label).inc();
@@ -707,7 +707,7 @@ public class RawKVClient implements AutoCloseable {
 
   private Pair<List<Batch>, List<KvPair>> doSendBatchGetInBatchesWithRetry(
       BackOffer backOffer, Batch batch) {
-    RegionStoreClient client = clientBuilder.build(batch.getRegion());
+    RegionStoreClient client = clientBuilder.build(batch.getRegion(), backOffer);
     try {
       List<KvPair> partialResult = client.rawBatchGet(backOffer, batch.getKeys());
       return Pair.create(new ArrayList<>(), partialResult);
@@ -748,7 +748,7 @@ public class RawKVClient implements AutoCloseable {
 
   private List<Batch> doSendBatchDeleteInBatchesWithRetry(
       BackOffer backOffer, Batch batch, boolean atomic) {
-    RegionStoreClient client = clientBuilder.build(batch.getRegion());
+    RegionStoreClient client = clientBuilder.build(batch.getRegion(), backOffer);
     try {
       client.rawBatchDelete(backOffer, batch.getKeys(), atomic);
       return new ArrayList<>();
@@ -798,7 +798,7 @@ public class RawKVClient implements AutoCloseable {
   }
 
   private List<DeleteRange> doSendDeleteRangeWithRetry(BackOffer backOffer, DeleteRange range) {
-    try (RegionStoreClient client = clientBuilder.build(range.getRegion())) {
+    try (RegionStoreClient client = clientBuilder.build(range.getRegion(), backOffer)) {
       client.setTimeout(conf.getScanTimeout());
       client.rawDeleteRange(backOffer, range.getStartKey(), range.getEndKey());
       return new ArrayList<>();


### PR DESCRIPTION
Signed-off-by: marsishandsome <marsishandsome@gmail.com>

### What problem does this PR solve? <!--add issue link with summary if exists-->
user cannot control the backoff time for pd, currently 40s written in code.

### What is changed and how it works?
1. use `tikv.rawkv.default_backoff_in_ms` as default backoff in `RegionManager` and `RegionStoreClient`
2. let RawKVClient share the same backoff in all the steps, e.g. put：get region from pd -> put key value to tikv

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to be included in the release note
