### PR TITLE
fix unclosed Thread when create TiSession error

### DIFF
--- a/src/main/java/org/tikv/common/TiSession.java
+++ b/src/main/java/org/tikv/common/TiSession.java
@@ -77,6 +77,10 @@ public class TiSession implements AutoCloseable {
   private static final int MAX_SPLIT_REGION_STACK_DEPTH = 6;
 
   public TiSession(TiConfiguration conf) {
+    // may throw org.tikv.common.MetricsServer  - http server not up
+    // put it at the beginning of this function to avoid unclosed Thread
+    this.metricsServer = MetricsServer.getInstance(conf);
+
     this.conf = conf;
     this.channelFactory =
         conf.isTlsEnable()
@@ -92,7 +96,6 @@ public class TiSession implements AutoCloseable {
 
     this.client = PDClient.createRaw(conf, channelFactory);
     this.enableGrpcForward = conf.getEnableGrpcForward();
-    this.metricsServer = MetricsServer.getInstance(conf);
     if (this.enableGrpcForward) {
       logger.info("enable grpc forward for high available");
     }


### PR DESCRIPTION
Signed-off-by: marsishandsome <marsishandsome@gmail.com>

### What problem does this PR solve? <!--add issue link with summary if exists-->
If the metrics HTTP port is not free, TiSession will leave a unclosed Thread in PDClient.

### What is changed and how it works?
put `MetricsServer.getInstance` at the beginning of this function to avoid unclosed Thread

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to be included in the release note
