### PR TITLE
fix Region Exception occurred EpochNotMatch

### DIFF
--- a/src/main/java/org/tikv/common/operation/RegionErrorHandler.java
+++ b/src/main/java/org/tikv/common/operation/RegionErrorHandler.java
@@ -175,12 +175,12 @@ public class RegionErrorHandler<RespT> implements ErrorHandler<RespT> {
     return false;
   }
 
+  // ref: https://github.com/tikv/client-go/blob/tidb-5.2/internal/locate/region_request.go#L985
   // OnRegionEpochNotMatch removes the old region and inserts new regions into the cache.
   // It returns whether retries the request because it's possible the region epoch is ahead of
   // TiKV's due to slow appling.
   private boolean onRegionEpochNotMatch(BackOffer backOffer, List<Metapb.Region> currentRegions) {
     if (currentRegions.size() == 0) {
-      logger.warn("currentRegions.size() == 0");
       this.regionManager.onRegionStale(recv.getRegion());
       return false;
     }
@@ -213,12 +213,10 @@ public class RegionErrorHandler<RespT> implements ErrorHandler<RespT> {
     }
 
     if (needInvalidateOld) {
-      logger.warn("needInvalidateOld, region=" + recv.getRegion());
       this.regionManager.onRegionStale(recv.getRegion());
     }
 
     for (TiRegion region : newRegions) {
-      logger.warn("insertRegionToCache, region=" + region);
       regionManager.insertRegionToCache(region);
     }
 

--- a/src/main/java/org/tikv/common/region/RegionCache.java
+++ b/src/main/java/org/tikv/common/region/RegionCache.java
@@ -99,6 +99,7 @@ public class RegionCache {
         keyToRegionIdCache.remove(makeRange(oldRegion.getStartKey(), oldRegion.getEndKey()));
       }
       regionCache.put(region.getId(), region);
+      keyToRegionIdCache.put(makeRange(region.getStartKey(), region.getEndKey()), region.getId());
     } catch (Exception ignore) {
     }
   }

--- a/src/main/java/org/tikv/common/region/RegionCache.java
+++ b/src/main/java/org/tikv/common/region/RegionCache.java
@@ -92,6 +92,17 @@ public class RegionCache {
     }
   }
 
+  public synchronized void insertRegionToCache(TiRegion region) {
+    try {
+      TiRegion oldRegion = regionCache.get(region.getId());
+      if (oldRegion != null) {
+        keyToRegionIdCache.remove(makeRange(oldRegion.getStartKey(), oldRegion.getEndKey()));
+      }
+      regionCache.put(region.getId(), region);
+    } catch (Exception ignore) {
+    }
+  }
+
   public synchronized boolean updateRegion(TiRegion expected, TiRegion region) {
     try {
       if (logger.isDebugEnabled()) {

--- a/src/main/java/org/tikv/common/region/RegionManager.java
+++ b/src/main/java/org/tikv/common/region/RegionManager.java
@@ -181,6 +181,12 @@ public class RegionManager {
     return Pair.create(region, store);
   }
 
+  public TiRegion createRegion(Metapb.Region region, BackOffer backOffer) {
+    List<Metapb.Peer> peers = region.getPeersList();
+    List<TiStore> stores = getRegionStore(peers, backOffer);
+    return new TiRegion(conf, region, null, peers, stores);
+  }
+
   private TiRegion createRegion(Metapb.Region region, Metapb.Peer leader, BackOffer backOffer) {
     List<Metapb.Peer> peers = region.getPeersList();
     List<TiStore> stores = getRegionStore(peers, backOffer);
@@ -260,6 +266,10 @@ public class RegionManager {
 
   public void invalidateRegion(TiRegion region) {
     cache.invalidateRegion(region);
+  }
+
+  public void insertRegionToCache(TiRegion region) {
+    cache.insertRegionToCache(region);
   }
 
   private BackOffer defaultBackOff() {

--- a/src/main/java/org/tikv/common/region/RegionManager.java
+++ b/src/main/java/org/tikv/common/region/RegionManager.java
@@ -100,6 +100,7 @@ public class RegionManager {
       if (region == null) {
         logger.debug("Key not found in keyToRegionIdCache:" + formatBytesUTF8(key));
         Pair<Metapb.Region, Metapb.Peer> regionAndLeader = pdClient.getRegionByKey(backOffer, key);
+        logger.warn("getRegionByKey: regionAndLeader=" + regionAndLeader);
         region =
             cache.putRegion(createRegion(regionAndLeader.first, regionAndLeader.second, backOffer));
       }

--- a/src/main/java/org/tikv/common/region/RegionManager.java
+++ b/src/main/java/org/tikv/common/region/RegionManager.java
@@ -100,7 +100,6 @@ public class RegionManager {
       if (region == null) {
         logger.debug("Key not found in keyToRegionIdCache:" + formatBytesUTF8(key));
         Pair<Metapb.Region, Metapb.Peer> regionAndLeader = pdClient.getRegionByKey(backOffer, key);
-        logger.warn("getRegionByKey: regionAndLeader=" + regionAndLeader);
         region =
             cache.putRegion(createRegion(regionAndLeader.first, regionAndLeader.second, backOffer));
       }

--- a/src/main/java/org/tikv/common/region/TiRegion.java
+++ b/src/main/java/org/tikv/common/region/TiRegion.java
@@ -82,6 +82,10 @@ public class TiRegion implements Serializable {
     replicaIdx = 0;
   }
 
+  public TiConfiguration getConf() {
+    return conf;
+  }
+
   public Peer getLeader() {
     return leader;
   }
@@ -269,6 +273,18 @@ public class TiRegion implements Serializable {
       this.id = id;
       this.confVer = confVer;
       this.ver = ver;
+    }
+
+    public long getId() {
+      return id;
+    }
+
+    public long getConfVer() {
+      return confVer;
+    }
+
+    public long getVer() {
+      return ver;
     }
 
     @Override

--- a/src/main/java/org/tikv/raw/RawKVClient.java
+++ b/src/main/java/org/tikv/raw/RawKVClient.java
@@ -133,6 +133,7 @@ public class RawKVClient implements AutoCloseable {
       BackOffer backOffer = ConcreteBackOffer.newDeadlineBackOff(conf.getRawKVWriteTimeoutInMS());
       while (true) {
         RegionStoreClient client = clientBuilder.build(key, backOffer);
+        logger.warn("put region: " + client.getRegion().toString());
         try {
           client.rawPut(backOffer, key, value, ttl, atomic);
           RAW_REQUEST_SUCCESS.labels(label).inc();
@@ -178,6 +179,7 @@ public class RawKVClient implements AutoCloseable {
       BackOffer backOffer = ConcreteBackOffer.newDeadlineBackOff(conf.getRawKVWriteTimeoutInMS());
       while (true) {
         RegionStoreClient client = clientBuilder.build(key, backOffer);
+        logger.warn("putIfAbsent region: " + client.getRegion().toString());
         try {
           ByteString result = client.rawPutIfAbsent(backOffer, key, value, ttl);
           RAW_REQUEST_SUCCESS.labels(label).inc();
@@ -263,6 +265,7 @@ public class RawKVClient implements AutoCloseable {
       BackOffer backOffer = ConcreteBackOffer.newDeadlineBackOff(conf.getRawKVReadTimeoutInMS());
       while (true) {
         RegionStoreClient client = clientBuilder.build(key, backOffer);
+        logger.warn("get region: " + client.getRegion().toString());
         try {
           ByteString result = client.rawGet(backOffer, key);
           RAW_REQUEST_SUCCESS.labels(label).inc();

--- a/src/main/java/org/tikv/raw/RawKVClient.java
+++ b/src/main/java/org/tikv/raw/RawKVClient.java
@@ -133,7 +133,6 @@ public class RawKVClient implements AutoCloseable {
       BackOffer backOffer = ConcreteBackOffer.newDeadlineBackOff(conf.getRawKVWriteTimeoutInMS());
       while (true) {
         RegionStoreClient client = clientBuilder.build(key, backOffer);
-        logger.warn("put region: " + client.getRegion().toString());
         try {
           client.rawPut(backOffer, key, value, ttl, atomic);
           RAW_REQUEST_SUCCESS.labels(label).inc();
@@ -179,7 +178,6 @@ public class RawKVClient implements AutoCloseable {
       BackOffer backOffer = ConcreteBackOffer.newDeadlineBackOff(conf.getRawKVWriteTimeoutInMS());
       while (true) {
         RegionStoreClient client = clientBuilder.build(key, backOffer);
-        logger.warn("putIfAbsent region: " + client.getRegion().toString());
         try {
           ByteString result = client.rawPutIfAbsent(backOffer, key, value, ttl);
           RAW_REQUEST_SUCCESS.labels(label).inc();
@@ -265,7 +263,6 @@ public class RawKVClient implements AutoCloseable {
       BackOffer backOffer = ConcreteBackOffer.newDeadlineBackOff(conf.getRawKVReadTimeoutInMS());
       while (true) {
         RegionStoreClient client = clientBuilder.build(key, backOffer);
-        logger.warn("get region: " + client.getRegion().toString());
         try {
           ByteString result = client.rawGet(backOffer, key);
           RAW_REQUEST_SUCCESS.labels(label).inc();


### PR DESCRIPTION
Signed-off-by: marsishandsome <marsishandsome@gmail.com>

### What problem does this PR solve? <!--add issue link with summary if exists-->

close https://github.com/tikv/client-java/issues/304 

When region splits, the region info on PD may not be updated in a few seconds.
Clients should use the new region info in `RegionEpochNotMatch ERROR` to update the local region cache.

### What is changed and how it works?
OnRegionEpochNotMatch removes the old region and inserts new regions into the cache.

ref: https://github.com/tikv/client-go/blob/tidb-5.2/internal/locate/region_request.go#L985

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to be included in the release note
