### PR TITLE
Retry when OtherError contains message: region xx is missing

### DIFF
--- a/src/main/java/org/tikv/common/operation/RegionErrorHandler.java
+++ b/src/main/java/org/tikv/common/operation/RegionErrorHandler.java
@@ -162,7 +162,8 @@ public class RegionErrorHandler<RespT> implements ErrorHandler<RespT> {
     // Upper level may split this task.
     invalidateRegionStoreCache(recv.getRegion());
     // retry if raft proposal is dropped, it indicates the store is in the middle of transition
-    if (error.getMessage().contains("Raft ProposalDropped")) {
+    if (error.getMessage().contains("Raft ProposalDropped")
+        || error.getMessage().contains("is missing")) {
       backOffer.doBackOff(
           BackOffFunction.BackOffFuncType.BoRegionMiss, new GrpcException(error.getMessage()));
       return true;


### PR DESCRIPTION
Retry when OtherError contains message: `region xxx is missing`

`Region is missing` indicates the required region does not exist on the current store. It may have been migrated to other stores. We could safely retry the query because the region cache has been invalidated.