### PR TITLE
shuffle PD addresses so that clients call getMembers from different PD

### DIFF
--- a/src/main/java/org/tikv/common/PDClient.java
+++ b/src/main/java/org/tikv/common/PDClient.java
@@ -35,6 +35,8 @@ import io.grpc.stub.MetadataUtils;
 import io.prometheus.client.Histogram;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -559,7 +561,9 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDStub>
 
   private void initCluster() {
     GetMembersResponse resp = null;
-    List<URI> pdAddrs = getConf().getPdAddrs();
+    List<URI> pdAddrs = new ArrayList<>(getConf().getPdAddrs());
+    // shuffle PD addresses so that clients call getMembers from different PD
+    Collections.shuffle(pdAddrs);
     this.pdAddrs = pdAddrs;
     this.etcdClient =
         Client.builder()


### PR DESCRIPTION
Signed-off-by: marsishandsome <marsishandsome@gmail.com>

### What problem does this PR solve? <!--add issue link with summary if exists-->
When starting many clients at the same time, PD may be the hotspot.

### What is changed and how it works?
shuffle PD addresses so that clients call getMembers from different PD

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to be included in the release note
