### PR TITLE
TwoPhaseCommiter log should be debug level

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ After building, add following lines into your `pom.xml` if you are using Maven
 <dependency>
 	<groupId>org.tikv</groupId>
 	<artifactId>tikv-client-java</artifactId>
-	<version>3.0.1</version>
+	<version>3.1.0</version>
 </dependency>
 ```
 
@@ -78,60 +78,6 @@ public class Main {
 		RawKVClient client = session.createRawClient();
 	}
 }
-```
-
-### API
-
-```java
-/**
- * Put a raw key-value pair to TiKV
- *
- * @param key raw key
- * @param value raw value
- */
-void put(ByteString key, ByteString value)
-```
-
-```java
-/**
- * Get a raw key-value pair from TiKV if key exists
- *
- * @param key raw key
- * @return a ByteString value if key exists, ByteString.EMPTY if key does not exist
- */
-ByteString get(ByteString key)
-```
-
-```java
-/**
- * Scan raw key-value pairs from TiKV in range [startKey, endKey)
- *
- * @param startKey raw start key, inclusive
- * @param endKey raw end key, exclusive
- * @param limit limit of key-value pairs scanned, should be less than {@link #MAX_RAW_SCAN_LIMIT}
- * @return list of key-value pairs in range
- */
-List<Kvrpcpb.KvPair> scan(ByteString startKey, ByteString endKey, int limit)
-```
-
-```java
-/**
- * Scan raw key-value pairs from TiKV in range [startKey, endKey)
- *
- * @param startKey raw start key, inclusive
- * @param limit limit of key-value pairs scanned, should be less than {@link #MAX_RAW_SCAN_LIMIT}
- * @return list of key-value pairs in range
- */
-List<Kvrpcpb.KvPair> scan(ByteString startKey, int limit)
-```
-
-```java
-/**
- * Delete a raw key-value pair from TiKV if key exists
- *
- * @param key raw key to be deleted
- */
-void delete(ByteString key)
 ```
 
 ## Java Client Configuration Parameter

--- a/src/main/java/org/tikv/txn/TwoPhaseCommitter.java
+++ b/src/main/java/org/tikv/txn/TwoPhaseCommitter.java
@@ -396,7 +396,7 @@ public class TwoPhaseCommitter {
       BatchKeys batchKeys,
       Map<ByteString, Kvrpcpb.Mutation> mutations)
       throws TiBatchWriteException {
-    LOG.info(
+    LOG.debug(
         "start prewrite secondary key, row={}, size={}KB, regionId={}",
         batchKeys.getKeys().size(),
         batchKeys.getSizeInKB(),
@@ -444,7 +444,7 @@ public class TwoPhaseCommitter {
         throw new TiBatchWriteException(errorMsg, e);
       }
     }
-    LOG.info(
+    LOG.debug(
         "prewrite secondary key successfully, row={}, size={}KB, regionId={}",
         batchKeys.getKeys().size(),
         batchKeys.getSizeInKB(),

--- a/src/test/java/Test.java
+++ b/src/test/java/Test.java
@@ -1,0 +1,2 @@
+package PACKAGE_NAME;public class Test {
+}

--- a/src/test/java/Test.java
+++ b/src/test/java/Test.java
@@ -1,2 +1,0 @@
-package PACKAGE_NAME;public class Test {
-}


### PR DESCRIPTION
The log of `org.tikv.txn.TwoPhaseCommitter` is too large,  which will cause the really useful logs to be hidden.

![image](https://user-images.githubusercontent.com/45056332/142413051-d5534cf1-2761-4b9b-9b4f-336e8e10b30f.png)
