### PR TITLE
Fix pd request throws invalid store id

### DIFF
--- a/src/main/java/org/tikv/common/PDClient.java
+++ b/src/main/java/org/tikv/common/PDClient.java
@@ -247,7 +247,7 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDFutureStub>
 
       GetRegionResponse resp =
           callWithRetry(backOffer, PDGrpc.getGetRegionMethod(), request, handler);
-      return Pair.create(decodeRegion(resp.getRegion()), resp.getLeader());
+      return new Pair<Metapb.Region, Metapb.Peer>(decodeRegion(resp.getRegion()), resp.getLeader());
     } finally {
       requestTimer.observeDuration();
     }
@@ -262,7 +262,7 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDFutureStub>
 
     GetRegionResponse resp =
         callWithRetry(backOffer, PDGrpc.getGetRegionByIDMethod(), request, handler);
-    return Pair.create(decodeRegion(resp.getRegion()), resp.getLeader());
+    return new Pair<Metapb.Region, Metapb.Peer>(decodeRegion(resp.getRegion()), resp.getLeader());
   }
 
   private Supplier<GetStoreRequest> buildGetStoreReq(long storeId) {

--- a/src/main/java/org/tikv/common/PDClient.java
+++ b/src/main/java/org/tikv/common/PDClient.java
@@ -247,7 +247,7 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDFutureStub>
 
       GetRegionResponse resp =
           callWithRetry(backOffer, PDGrpc.getGetRegionMethod(), request, handler);
-      return new Pair<Metapb.Region, Metapb.Peer>(decodeRegion(resp.getRegion()), resp.getLeader());
+      return Pair.create(decodeRegion(resp.getRegion()), resp.getLeader());
     } finally {
       requestTimer.observeDuration();
     }
@@ -262,7 +262,7 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDFutureStub>
 
     GetRegionResponse resp =
         callWithRetry(backOffer, PDGrpc.getGetRegionByIDMethod(), request, handler);
-    return new Pair<Metapb.Region, Metapb.Peer>(decodeRegion(resp.getRegion()), resp.getLeader());
+    return Pair.create(decodeRegion(resp.getRegion()), resp.getLeader());
   }
 
   private Supplier<GetStoreRequest> buildGetStoreReq(long storeId) {

--- a/src/main/java/org/tikv/common/exception/InvalidStoreException.java
+++ b/src/main/java/org/tikv/common/exception/InvalidStoreException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 PingCAP, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.tikv.common.exception;
+
+public class InvalidStoreException extends TiKVException {
+
+  public InvalidStoreException(long storeId) {
+    super(String.format("Invalid storeId = %d", storeId));
+  }
+}

--- a/src/main/java/org/tikv/common/exception/InvalidStoreException.java
+++ b/src/main/java/org/tikv/common/exception/InvalidStoreException.java
@@ -18,6 +18,6 @@ package org.tikv.common.exception;
 public class InvalidStoreException extends TiKVException {
 
   public InvalidStoreException(long storeId) {
-    super(String.format("Invalid storeId = %d", storeId));
+    super(String.format("Invalid storeId: %d", storeId));
   }
 }

--- a/src/main/java/org/tikv/common/operation/PDErrorHandler.java
+++ b/src/main/java/org/tikv/common/operation/PDErrorHandler.java
@@ -20,6 +20,8 @@ package org.tikv.common.operation;
 import static org.tikv.common.pd.PDError.buildFromPdpbError;
 
 import java.util.function.Function;
+
+import io.grpc.StatusRuntimeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.tikv.common.PDClient;
@@ -75,6 +77,10 @@ public class PDErrorHandler<RespT> implements ErrorHandler<RespT> {
   @Override
   public boolean handleRequestError(BackOffer backOffer, Exception e) {
     backOffer.doBackOff(BackOffFunction.BackOffFuncType.BoPDRPC, e);
+    // store id is not found
+    if (e instanceof StatusRuntimeException && e.getMessage().contains("invalid store ID")) {
+      return false;
+    }
     client.updateLeaderOrforwardFollower();
     return true;
   }

--- a/src/main/java/org/tikv/common/operation/PDErrorHandler.java
+++ b/src/main/java/org/tikv/common/operation/PDErrorHandler.java
@@ -75,11 +75,11 @@ public class PDErrorHandler<RespT> implements ErrorHandler<RespT> {
 
   @Override
   public boolean handleRequestError(BackOffer backOffer, Exception e) {
-    backOffer.doBackOff(BackOffFunction.BackOffFuncType.BoPDRPC, e);
     // store id is not found
     if (e instanceof StatusRuntimeException && e.getMessage().contains("invalid store ID")) {
       return false;
     }
+    backOffer.doBackOff(BackOffFunction.BackOffFuncType.BoPDRPC, e);
     client.updateLeaderOrforwardFollower();
     return true;
   }

--- a/src/main/java/org/tikv/common/operation/PDErrorHandler.java
+++ b/src/main/java/org/tikv/common/operation/PDErrorHandler.java
@@ -19,9 +19,8 @@ package org.tikv.common.operation;
 
 import static org.tikv.common.pd.PDError.buildFromPdpbError;
 
-import java.util.function.Function;
-
 import io.grpc.StatusRuntimeException;
+import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.tikv.common.PDClient;

--- a/src/main/java/org/tikv/common/region/RegionManager.java
+++ b/src/main/java/org/tikv/common/region/RegionManager.java
@@ -33,7 +33,6 @@ import org.tikv.common.TiConfiguration;
 import org.tikv.common.exception.GrpcException;
 import org.tikv.common.exception.InvalidStoreException;
 import org.tikv.common.exception.TiClientInternalException;
-import org.tikv.common.exception.TiKVException;
 import org.tikv.common.util.BackOffer;
 import org.tikv.common.util.ChannelFactory;
 import org.tikv.common.util.ConcreteBackOffer;
@@ -200,7 +199,8 @@ public class RegionManager {
       if (store == null) {
         store = new TiStore(pdClient.getStore(backOffer, id));
       }
-      // if we did not get store info from pd or the store is already tombstone, remove store from cache
+      // if we did not get store info from pd or the store is already tombstone, remove store from
+      // cache
       if (store.getStore() == null || store.getStore().getState().equals(StoreState.Tombstone)) {
         return null;
       }
@@ -219,7 +219,7 @@ public class RegionManager {
 
   public TiStore getStoreById(long id, BackOffer backOffer) {
     TiStore store = getStoreByIdWithBackOff(id, backOffer);
-    if (store == null || store.getStore() == null) {
+    if (store == null) {
       cache.clearAll();
       throw new InvalidStoreException(id);
     }

--- a/src/main/java/org/tikv/common/region/RegionManager.java
+++ b/src/main/java/org/tikv/common/region/RegionManager.java
@@ -225,6 +225,7 @@ public class RegionManager {
   public TiStore getStoreById(long id, BackOffer backOffer) {
     TiStore store = getStoreByIdWithBackOff(id, backOffer);
     if (store == null) {
+      logger.warn(String.format("failed to fetch store %d, the store may be missing", id));
       cache.clearAll();
       throw new InvalidStoreException(id);
     }

--- a/src/main/java/org/tikv/raw/RawKVClient.java
+++ b/src/main/java/org/tikv/raw/RawKVClient.java
@@ -146,9 +146,8 @@ public class RawKVClient implements AutoCloseable {
         ConcreteBackOffer.newDeadlineBackOff(conf.getRawKVWriteTimeoutInMS(), slowLog);
     try {
       while (true) {
-        RegionStoreClient client = clientBuilder.build(key, backOffer);
-        slowLog.addProperty("region", client.getRegion().toString());
-        try {
+        try (RegionStoreClient client = clientBuilder.build(key, backOffer)) {
+          slowLog.addProperty("region", client.getRegion().toString());
           client.rawPut(backOffer, key, value, ttl, atomic);
           RAW_REQUEST_SUCCESS.labels(label).inc();
           return;
@@ -203,9 +202,8 @@ public class RawKVClient implements AutoCloseable {
         ConcreteBackOffer.newDeadlineBackOff(conf.getRawKVWriteTimeoutInMS(), slowLog);
     try {
       while (true) {
-        RegionStoreClient client = clientBuilder.build(key, backOffer);
-        slowLog.addProperty("region", client.getRegion().toString());
-        try {
+        try (RegionStoreClient client = clientBuilder.build(key, backOffer)) {
+          slowLog.addProperty("region", client.getRegion().toString());
           ByteString result = client.rawPutIfAbsent(backOffer, key, value, ttl);
           RAW_REQUEST_SUCCESS.labels(label).inc();
           return result;
@@ -311,9 +309,8 @@ public class RawKVClient implements AutoCloseable {
         ConcreteBackOffer.newDeadlineBackOff(conf.getRawKVReadTimeoutInMS(), slowLog);
     try {
       while (true) {
-        RegionStoreClient client = clientBuilder.build(key, backOffer);
-        slowLog.addProperty("region", client.getRegion().toString());
-        try {
+        try (RegionStoreClient client = clientBuilder.build(key, backOffer)) {
+          slowLog.addProperty("region", client.getRegion().toString());
           ByteString result = client.rawGet(backOffer, key);
           RAW_REQUEST_SUCCESS.labels(label).inc();
           return result;
@@ -434,9 +431,8 @@ public class RawKVClient implements AutoCloseable {
         ConcreteBackOffer.newDeadlineBackOff(conf.getRawKVReadTimeoutInMS(), slowLog);
     try {
       while (true) {
-        RegionStoreClient client = clientBuilder.build(key, backOffer);
-        slowLog.addProperty("region", client.getRegion().toString());
-        try {
+        try (RegionStoreClient client = clientBuilder.build(key, backOffer)) {
+          slowLog.addProperty("region", client.getRegion().toString());
           Long result = client.rawGetKeyTTL(backOffer, key);
           RAW_REQUEST_SUCCESS.labels(label).inc();
           return result;
@@ -709,9 +705,8 @@ public class RawKVClient implements AutoCloseable {
         ConcreteBackOffer.newDeadlineBackOff(conf.getRawKVWriteTimeoutInMS(), slowLog);
     try {
       while (true) {
-        RegionStoreClient client = clientBuilder.build(key, backOffer);
-        slowLog.addProperty("region", client.getRegion().toString());
-        try {
+        try (RegionStoreClient client = clientBuilder.build(key, backOffer)) {
+          slowLog.addProperty("region", client.getRegion().toString());
           client.rawDelete(backOffer, key, atomic);
           RAW_REQUEST_SUCCESS.labels(label).inc();
           return;
@@ -887,8 +882,8 @@ public class RawKVClient implements AutoCloseable {
 
   private Pair<List<Batch>, List<KvPair>> doSendBatchGetInBatchesWithRetry(
       BackOffer backOffer, Batch batch) {
-    RegionStoreClient client = clientBuilder.build(batch.getRegion(), backOffer);
-    try {
+
+    try (RegionStoreClient client = clientBuilder.build(batch.getRegion(), backOffer)) {
       List<KvPair> partialResult = client.rawBatchGet(backOffer, batch.getKeys());
       return Pair.create(new ArrayList<>(), partialResult);
     } catch (final TiKVException e) {
@@ -939,8 +934,7 @@ public class RawKVClient implements AutoCloseable {
 
   private List<Batch> doSendBatchDeleteInBatchesWithRetry(
       BackOffer backOffer, Batch batch, boolean atomic) {
-    RegionStoreClient client = clientBuilder.build(batch.getRegion(), backOffer);
-    try {
+    try (RegionStoreClient client = clientBuilder.build(batch.getRegion(), backOffer)) {
       client.rawBatchDelete(backOffer, batch.getKeys(), atomic);
       return new ArrayList<>();
     } catch (final TiKVException e) {

--- a/src/test/java/org/tikv/common/RegionManagerTest.java
+++ b/src/test/java/org/tikv/common/RegionManagerTest.java
@@ -161,7 +161,12 @@ public class RegionManagerTest extends PDMockServerTest {
                 StoreState.Tombstone,
                 GrpcUtils.makeStoreLabel("k1", "v1"),
                 GrpcUtils.makeStoreLabel("k2", "v2"))));
-    assertNull(mgr.getStoreById(storeId + 1));
+
+    try {
+      mgr.getStoreById(storeId + 1);
+      fail();
+    } catch (Exception ignored) {
+    }
 
     mgr.invalidateStore(storeId);
     try {


### PR DESCRIPTION
When the Java Client requests a store id that PD does not recognize, e.g., the PD was scaled-in and does not know about a scaled-out TiKV, the PD will respond with a `StatusRuntimeException` rather than an error wrapped by Response itself.

Thus we should resolve StatusRuntimeException so that the invalid store info can be dealt with correctly by clearing all-region/store cache info.