### PR TITLE
[close #412] Fix gRPC timeout not set for some requests

### DIFF
--- a/src/main/java/org/tikv/common/operation/PDErrorHandler.java
+++ b/src/main/java/org/tikv/common/operation/PDErrorHandler.java
@@ -59,7 +59,7 @@ public class PDErrorHandler<RespT> implements ErrorHandler<RespT> {
         case PD_ERROR:
           backOffer.doBackOff(
               BackOffFunction.BackOffFuncType.BoPDRPC, new GrpcException(error.toString()));
-          return client.updateLeaderOrForwardFollower();
+          return client.updateLeaderOrForwardFollower(backOffer.getSlowLog());
         case REGION_PEER_NOT_ELECTED:
           logger.debug(error.getMessage());
           backOffer.doBackOff(
@@ -79,6 +79,6 @@ public class PDErrorHandler<RespT> implements ErrorHandler<RespT> {
       return false;
     }
     backOffer.doBackOff(BackOffFunction.BackOffFuncType.BoPDRPC, e);
-    return client.updateLeaderOrForwardFollower();
+    return client.updateLeaderOrForwardFollower(backOffer.getSlowLog());
   }
 }

--- a/src/main/java/org/tikv/common/operation/PDErrorHandler.java
+++ b/src/main/java/org/tikv/common/operation/PDErrorHandler.java
@@ -58,8 +58,7 @@ public class PDErrorHandler<RespT> implements ErrorHandler<RespT> {
         case PD_ERROR:
           backOffer.doBackOff(
               BackOffFunction.BackOffFuncType.BoPDRPC, new GrpcException(error.toString()));
-          client.updateLeaderOrforwardFollower();
-          return true;
+          return client.updateLeaderOrForwardFollower();
         case REGION_PEER_NOT_ELECTED:
           logger.debug(error.getMessage());
           backOffer.doBackOff(
@@ -75,7 +74,6 @@ public class PDErrorHandler<RespT> implements ErrorHandler<RespT> {
   @Override
   public boolean handleRequestError(BackOffer backOffer, Exception e) {
     backOffer.doBackOff(BackOffFunction.BackOffFuncType.BoPDRPC, e);
-    client.updateLeaderOrforwardFollower();
-    return true;
+    return client.updateLeaderOrForwardFollower();
   }
 }

--- a/src/main/java/org/tikv/common/operation/PDErrorHandler.java
+++ b/src/main/java/org/tikv/common/operation/PDErrorHandler.java
@@ -79,6 +79,7 @@ public class PDErrorHandler<RespT> implements ErrorHandler<RespT> {
       return false;
     }
     backOffer.doBackOff(BackOffFunction.BackOffFuncType.BoPDRPC, e);
+    logger.info("handle request error: ", e);
     return client.updateLeaderOrForwardFollower(backOffer.getSlowLog());
   }
 }

--- a/src/main/java/org/tikv/common/region/AbstractRegionStoreClient.java
+++ b/src/main/java/org/tikv/common/region/AbstractRegionStoreClient.java
@@ -337,11 +337,13 @@ public abstract class AbstractRegionStoreClient
         try {
           // any answer will do
           Kvrpcpb.RawGetResponse resp = task.task.get();
-          logger.info(
-              String.format(
-                  "rawGetResponse indicates forward from [%s] to [%s]",
-                  task.store.getAddress(), store.getAddress()));
-          return store.withProxy(task.store);
+          if (resp != null) {
+            logger.info(
+                String.format(
+                    "rawGetResponse indicates forward from [%s] to [%s]",
+                    task.store.getAddress(), store.getAddress()));
+            return store.withProxy(task.store);
+          }
         } catch (Exception ignored) {
         }
       }

--- a/src/main/java/org/tikv/common/region/AbstractRegionStoreClient.java
+++ b/src/main/java/org/tikv/common/region/AbstractRegionStoreClient.java
@@ -287,6 +287,11 @@ public abstract class AbstractRegionStoreClient
               // the peer is leader
               logger.info(
                   String.format("rawGet response indicates peer[%d] is leader", task.peer.getId()));
+              for (SwitchLeaderTask unfinishedTasks : responses) {
+                if (!unfinishedTasks.task.isDone()) {
+                  unfinishedTasks.task.cancel(true);
+                }
+              }
               return task.peer;
             }
           }

--- a/src/main/java/org/tikv/common/region/RegionCache.java
+++ b/src/main/java/org/tikv/common/region/RegionCache.java
@@ -110,7 +110,7 @@ public class RegionCache {
         logger.debug(String.format("invalidateRegion ID[%s]", region.getId()));
       }
       TiRegion oldRegion = regionCache.get(region.getId());
-      if (!expected.getMeta().equals(oldRegion.getMeta())) {
+      if (oldRegion != null && !expected.getMeta().equals(oldRegion.getMeta())) {
         return false;
       } else {
         if (oldRegion != null) {

--- a/src/main/java/org/tikv/common/region/RegionStoreClient.java
+++ b/src/main/java/org/tikv/common/region/RegionStoreClient.java
@@ -125,8 +125,10 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
       ManagedChannel channel = channelFactory.getChannel(addressStr, pdClient.getHostMapping());
 
       long timeout = conf.getTimeout();
-      TikvBlockingStub tikvBlockingStub = TikvGrpc.newBlockingStub(channel).withDeadlineAfter(timeout, TimeUnit.MILLISECONDS);
-      TikvGrpc.TikvFutureStub tikvAsyncStub = TikvGrpc.newFutureStub(channel).withDeadlineAfter(timeout, TimeUnit.MILLISECONDS);
+      TikvBlockingStub tikvBlockingStub =
+          TikvGrpc.newBlockingStub(channel).withDeadlineAfter(timeout, TimeUnit.MILLISECONDS);
+      TikvGrpc.TikvFutureStub tikvAsyncStub =
+          TikvGrpc.newFutureStub(channel).withDeadlineAfter(timeout, TimeUnit.MILLISECONDS);
 
       this.lockResolverClient =
           AbstractLockResolverClient.getInstance(
@@ -1257,13 +1259,23 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
         Metadata header = new Metadata();
         header.put(TiConfiguration.FORWARD_META_DATA_KEY, store.getStore().getAddress());
         long deadline = conf.getForwardTimeout();
-        blockingStub = MetadataUtils.attachHeaders(TikvGrpc.newBlockingStub(channel).withDeadlineAfter(deadline, TimeUnit.MILLISECONDS), header);
-        asyncStub = MetadataUtils.attachHeaders(TikvGrpc.newFutureStub(channel).withDeadlineAfter(deadline, TimeUnit.MILLISECONDS), header);
+        blockingStub =
+            MetadataUtils.attachHeaders(
+                TikvGrpc.newBlockingStub(channel)
+                    .withDeadlineAfter(deadline, TimeUnit.MILLISECONDS),
+                header);
+        asyncStub =
+            MetadataUtils.attachHeaders(
+                TikvGrpc.newFutureStub(channel).withDeadlineAfter(deadline, TimeUnit.MILLISECONDS),
+                header);
       } else {
         channel = channelFactory.getChannel(addressStr, pdClient.getHostMapping());
         long timeout = conf.getTimeout();
-        blockingStub = TikvGrpc.newBlockingStub(channel).withDeadlineAfter(timeout, TimeUnit.MILLISECONDS);
-        asyncStub = TikvGrpc.newFutureStub(channel).withDeadlineAfter(timeout, TimeUnit.MILLISECONDS);;
+        blockingStub =
+            TikvGrpc.newBlockingStub(channel).withDeadlineAfter(timeout, TimeUnit.MILLISECONDS);
+        asyncStub =
+            TikvGrpc.newFutureStub(channel).withDeadlineAfter(timeout, TimeUnit.MILLISECONDS);
+        ;
       }
 
       return new RegionStoreClient(

--- a/src/main/java/org/tikv/common/util/ConcreteBackOffer.java
+++ b/src/main/java/org/tikv/common/util/ConcreteBackOffer.java
@@ -127,17 +127,17 @@ public class ConcreteBackOffer implements BackOffer {
         backOffFunction =
             BackOffFunction.create(
                 TiConfiguration.getInt(TIKV_BO_REGION_MISS_BASE_IN_MS),
-                500,
+                100,
                 BackOffStrategy.NoJitter);
         break;
       case BoTxnLock:
         backOffFunction = BackOffFunction.create(200, 3000, BackOffStrategy.EqualJitter);
         break;
       case BoPDRPC:
-        backOffFunction = BackOffFunction.create(100, 600, BackOffStrategy.EqualJitter);
+        backOffFunction = BackOffFunction.create(10, 60, BackOffStrategy.EqualJitter);
         break;
       case BoTiKVRPC:
-        backOffFunction = BackOffFunction.create(10, 400, BackOffStrategy.EqualJitter);
+        backOffFunction = BackOffFunction.create(10, 80, BackOffStrategy.EqualJitter);
         break;
       case BoTxnNotFound:
         backOffFunction = BackOffFunction.create(2, 500, BackOffStrategy.NoJitter);

--- a/src/test/java/org/tikv/common/PDClientTest.java
+++ b/src/test/java/org/tikv/common/PDClientTest.java
@@ -36,7 +36,7 @@ public class PDClientTest extends PDMockServerTest {
   @Test
   public void testCreate() throws Exception {
     try (PDClient client = session.getPDClient()) {
-      assertEquals(client.getPdClientWrapper().getLeaderInfo(), LOCAL_ADDR + ":" + pdServer.port);
+      assertEquals(client.getPdClientWrapper().getLeaderAddr(), LOCAL_ADDR + ":" + pdServer.port);
       assertEquals(client.getHeader().getClusterId(), CLUSTER_ID);
     }
   }
@@ -47,7 +47,7 @@ public class PDClientTest extends PDMockServerTest {
       client.trySwitchLeader("http://" + LOCAL_ADDR + ":" + (pdServer.port + 1));
       assertEquals(
           "http://" + LOCAL_ADDR + ":" + (pdServer.port + 1),
-          client.getPdClientWrapper().getLeaderInfo());
+          client.getPdClientWrapper().getLeaderAddr());
     }
     tearDown();
     setUp(LOCAL_ADDR_IPV6);
@@ -55,7 +55,7 @@ public class PDClientTest extends PDMockServerTest {
       client.trySwitchLeader("http://" + LOCAL_ADDR_IPV6 + ":" + (pdServer.port + 2));
       assertEquals(
           "http://" + LOCAL_ADDR_IPV6 + ":" + (pdServer.port + 2),
-          client.getPdClientWrapper().getLeaderInfo());
+          client.getPdClientWrapper().getLeaderAddr());
     }
   }
 


### PR DESCRIPTION
close #412 

Some gRPC requests did not set `deadline`, so the whole API will not be limited to 850ms when network partition happens.

