### PR TITLE
Add a flag to determine if TiFlash is enabled

### DIFF
--- a/src/main/java/org/tikv/common/ConfigUtils.java
+++ b/src/main/java/org/tikv/common/ConfigUtils.java
@@ -76,6 +76,7 @@ public class ConfigUtils {
   public static final String TIKV_KEY_CERT_CHAIN = "tikv.key_cert_chain";
   public static final String TIKV_KEY_FILE = "tikv.key_file";
 
+  public static final String TIFLASH_ENABLE = "tiflash.enable";
   public static final String DEF_PD_ADDRESSES = "127.0.0.1:2379";
   public static final String DEF_TIMEOUT = "200ms";
   public static final String DEF_TIKV_GRPC_INGEST_TIMEOUT = "200s";
@@ -133,4 +134,5 @@ public class ConfigUtils {
   public static final int DEF_TIKV_GRPC_KEEPALIVE_TIME = 10;
   public static final int DEF_TIKV_GRPC_KEEPALIVE_TIMEOUT = 3;
   public static final boolean DEF_TIKV_TLS_ENABLE = false;
+  public static final boolean DEF_TIFLASH_ENABLE = false;
 }

--- a/src/main/java/org/tikv/common/PDClient.java
+++ b/src/main/java/org/tikv/common/PDClient.java
@@ -692,14 +692,16 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDStub>
         10,
         10,
         TimeUnit.SECONDS);
-    tiflashReplicaService =
-        Executors.newSingleThreadScheduledExecutor(
-            new ThreadFactoryBuilder()
-                .setNameFormat("PDClient-tiflash-replica-pool-%d")
-                .setDaemon(true)
-                .build());
-    tiflashReplicaService.scheduleAtFixedRate(
-        this::updateTiFlashReplicaStatus, 10, 10, TimeUnit.SECONDS);
+    if (conf.isTiFlashEnabled()) {
+      tiflashReplicaService =
+          Executors.newSingleThreadScheduledExecutor(
+              new ThreadFactoryBuilder()
+                  .setNameFormat("PDClient-tiflash-replica-pool-%d")
+                  .setDaemon(true)
+                  .build());
+      tiflashReplicaService.scheduleAtFixedRate(
+          this::updateTiFlashReplicaStatus, 10, 10, TimeUnit.SECONDS);
+    }
   }
 
   static class PDClientWrapper {

--- a/src/main/java/org/tikv/common/TiConfiguration.java
+++ b/src/main/java/org/tikv/common/TiConfiguration.java
@@ -121,6 +121,7 @@ public class TiConfiguration implements Serializable {
     setIfMissing(TIKV_GRPC_KEEPALIVE_TIME, DEF_TIKV_GRPC_KEEPALIVE_TIME);
     setIfMissing(TIKV_GRPC_KEEPALIVE_TIMEOUT, DEF_TIKV_GRPC_KEEPALIVE_TIMEOUT);
     setIfMissing(TIKV_TLS_ENABLE, DEF_TIKV_TLS_ENABLE);
+    setIfMissing(TIFLASH_ENABLE, DEF_TIFLASH_ENABLE);
   }
 
   public static void listAll() {
@@ -326,6 +327,8 @@ public class TiConfiguration implements Serializable {
   private String trustCertCollectionFile = getOption(TIKV_TRUST_CERT_COLLECTION).orElse(null);
   private String keyCertChainFile = getOption(TIKV_KEY_CERT_CHAIN).orElse(null);
   private String keyFile = getOption(TIKV_KEY_FILE).orElse(null);
+
+  private boolean tiFlashEnable = getBoolean(TIFLASH_ENABLE);
 
   private boolean isTest = false;
 
@@ -728,6 +731,10 @@ public class TiConfiguration implements Serializable {
 
   public void setKeepaliveTimeout(int timeout) {
     this.keepaliveTimeout = timeout;
+  }
+
+  public boolean isTiFlashEnabled() {
+    return tiFlashEnable;
   }
 
   public boolean isTlsEnable() {

--- a/src/test/java/org/tikv/common/TiConfigurationTest.java
+++ b/src/test/java/org/tikv/common/TiConfigurationTest.java
@@ -16,6 +16,7 @@
 package org.tikv.common;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 import org.junit.Test;
 
@@ -25,5 +26,11 @@ public class TiConfigurationTest {
   public void configFileTest() {
     TiConfiguration conf = TiConfiguration.createRawDefault();
     assertEquals("configFileTest", conf.getDBPrefix());
+  }
+
+  @Test
+  public void tiFlashDefaultValueTest() {
+    TiConfiguration conf = TiConfiguration.createRawDefault();
+    assertFalse(conf.isTiFlashEnabled());
   }
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
TiKV client currently assumes that TiFlash is deployed and starts a threadpool to periodically check tiflash replica status
https://github.com/tikv/client-java/issues/350

### What is changed and how it works?
Added a boolean flag to determine if tiflash is enabled . The default value is false.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 
Code changes

 - Has exported function/method change

Side effects

 - Increased code complexity


Related changes
 - Need to update the documentation

