### PR TITLE
Fix NullPointerException in getStore

### DIFF
--- a/src/main/java/org/tikv/common/PDClient.java
+++ b/src/main/java/org/tikv/common/PDClient.java
@@ -356,9 +356,16 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDFutureStub>
 
   @Override
   public Store getStore(BackOffer backOffer, long storeId) {
-    return callWithRetry(
-            backOffer, PDGrpc.getGetStoreMethod(), buildGetStoreReq(storeId), buildPDErrorHandler())
-        .getStore();
+    GetStoreResponse resp =
+        callWithRetry(
+            backOffer,
+            PDGrpc.getGetStoreMethod(),
+            buildGetStoreReq(storeId),
+            buildPDErrorHandler());
+    if (resp != null) {
+      return resp.getStore();
+    }
+    return null;
   }
 
   @Override

--- a/src/main/java/org/tikv/common/region/StoreHealthyChecker.java
+++ b/src/main/java/org/tikv/common/region/StoreHealthyChecker.java
@@ -74,7 +74,7 @@ public class StoreHealthyChecker implements Runnable {
   private boolean checkStoreTombstone(TiStore store) {
     try {
       Metapb.Store newStore = pdClient.getStore(ConcreteBackOffer.newRawKVBackOff(), store.getId());
-      if (newStore.getState() == Metapb.StoreState.Tombstone) {
+      if (newStore != null && newStore.getState() == Metapb.StoreState.Tombstone) {
         return true;
       }
     } catch (Exception e) {


### PR DESCRIPTION
If `callWIthRetry` returns a null response, `getStore` will throw NullPointerException.