### PR TITLE
log SlowLog if error occures

### DIFF
--- a/src/main/java/org/tikv/common/log/SlowLog.java
+++ b/src/main/java/org/tikv/common/log/SlowLog.java
@@ -22,5 +22,7 @@ public interface SlowLog {
 
   SlowLogSpan start(String name);
 
+  void setError(Throwable err);
+
   void log();
 }

--- a/src/main/java/org/tikv/common/log/SlowLogEmptyImpl.java
+++ b/src/main/java/org/tikv/common/log/SlowLogEmptyImpl.java
@@ -31,5 +31,8 @@ public class SlowLogEmptyImpl implements SlowLog {
   }
 
   @Override
+  public void setError(Throwable err) {}
+
+  @Override
   public void log() {}
 }

--- a/src/main/java/org/tikv/raw/RawKVClient.java
+++ b/src/main/java/org/tikv/raw/RawKVClient.java
@@ -151,6 +151,7 @@ public class RawKVClient implements AutoCloseable {
       }
     } catch (Exception e) {
       RAW_REQUEST_FAILURE.labels(label).inc();
+      slowLog.setError(e);
       throw e;
     } finally {
       requestTimer.observeDuration();
@@ -249,6 +250,7 @@ public class RawKVClient implements AutoCloseable {
       }
     } catch (Exception e) {
       RAW_REQUEST_FAILURE.labels(label).inc();
+      slowLog.setError(e);
       throw e;
     } finally {
       requestTimer.observeDuration();
@@ -291,6 +293,7 @@ public class RawKVClient implements AutoCloseable {
       RAW_REQUEST_SUCCESS.labels(label).inc();
     } catch (Exception e) {
       RAW_REQUEST_FAILURE.labels(label).inc();
+      slowLog.setError(e);
       throw e;
     } finally {
       requestTimer.observeDuration();
@@ -333,6 +336,7 @@ public class RawKVClient implements AutoCloseable {
       }
     } catch (Exception e) {
       RAW_REQUEST_FAILURE.labels(label).inc();
+      slowLog.setError(e);
       throw e;
     } finally {
       requestTimer.observeDuration();
@@ -367,6 +371,7 @@ public class RawKVClient implements AutoCloseable {
       return result;
     } catch (Exception e) {
       RAW_REQUEST_FAILURE.labels(label).inc();
+      slowLog.setError(e);
       throw e;
     } finally {
       requestTimer.observeDuration();
@@ -400,6 +405,7 @@ public class RawKVClient implements AutoCloseable {
       return;
     } catch (Exception e) {
       RAW_REQUEST_FAILURE.labels(label).inc();
+      slowLog.setError(e);
       throw e;
     } finally {
       requestTimer.observeDuration();
@@ -442,6 +448,7 @@ public class RawKVClient implements AutoCloseable {
       }
     } catch (Exception e) {
       RAW_REQUEST_FAILURE.labels(label).inc();
+      slowLog.setError(e);
       throw e;
     } finally {
       requestTimer.observeDuration();
@@ -589,6 +596,7 @@ public class RawKVClient implements AutoCloseable {
       return result;
     } catch (Exception e) {
       RAW_REQUEST_FAILURE.labels(label).inc();
+      slowLog.setError(e);
       throw e;
     } finally {
       requestTimer.observeDuration();
@@ -677,6 +685,7 @@ public class RawKVClient implements AutoCloseable {
       return result;
     } catch (Exception e) {
       RAW_REQUEST_FAILURE.labels(label).inc();
+      slowLog.setError(e);
       throw e;
     } finally {
       requestTimer.observeDuration();
@@ -745,6 +754,7 @@ public class RawKVClient implements AutoCloseable {
       }
     } catch (Exception e) {
       RAW_REQUEST_FAILURE.labels(label).inc();
+      slowLog.setError(e);
       throw e;
     } finally {
       requestTimer.observeDuration();


### PR DESCRIPTION
Signed-off-by: marsishandsome <marsishandsome@gmail.com>

close https://github.com/tikv/client-java/issues/362

Currently TiKV will only log `SlowLog` if `slowThresholdMS` exceeds.

Besides TiKV should also log `SlowLog `if error occures.
