### PR TITLE
fix seekLeaderStore NPE

### DIFF
--- a/src/main/java/org/tikv/common/region/AbstractRegionStoreClient.java
+++ b/src/main/java/org/tikv/common/region/AbstractRegionStoreClient.java
@@ -203,11 +203,14 @@ public abstract class AbstractRegionStoreClient
                   "update leader using switchLeader logic from store[%d] to store[%d]",
                   region.getLeader().getStoreId(), peer.getStoreId()));
           // update region cache
-          region = regionManager.updateLeader(region, peer.getStoreId());
-          // switch to leader store
-          store = currentLeaderStore;
-          updateClientStub();
-          return true;
+          TiRegion result = regionManager.updateLeader(region, peer.getStoreId());
+          if (result != null) {
+            region = result;
+            // switch to leader store
+            store = currentLeaderStore;
+            updateClientStub();
+          }
+          return false;
         }
       } else {
         // no leader found, some response does not return normally, there may be network partition.


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

This pull request fixes the NPE triggered by the double retry of `seekLeaderStore`. These buggy lines would also introduce another issue like `peer id not match` because the meta of the region is not updated.

### What is changed and how it works?

Once we change detected a reachable store we need to update the peer information of the region and retry in the most outside code.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
 - Manual test (add detailed scripts or steps below)


Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to be included in the release note
