### PR TITLE
warm up RawKVClient while creating it

### DIFF
--- a/src/main/java/org/tikv/common/TiSession.java
+++ b/src/main/java/org/tikv/common/TiSession.java
@@ -109,7 +109,12 @@ public class TiSession implements AutoCloseable {
 
     RegionStoreClientBuilder builder =
         new RegionStoreClientBuilder(conf, channelFactory, this.getRegionManager(), client);
-    return new RawKVClient(this, builder);
+    RawKVClient rawClient = new RawKVClient(this, builder);
+
+    // Warm up raw client to avoid a slow first call.
+    rawClient.get(ByteString.EMPTY);
+
+    return rawClient;
   }
 
   public KVClient createKVClient() {


### PR DESCRIPTION
Signed-off-by: iosmanthus <myosmanthustree@gmail.com>

### What problem does this PR solve? <!--add issue link with summary if exists-->

We find some initialization work that needs to do in the first gRPC call in `RawKVClient` which might result in a timeout in the first few gRPC calls.

First run:

![image](https://user-images.githubusercontent.com/16307070/145193389-b5da2877-a0cd-4785-b310-19abcc68f172.png)

Second run:

![image](https://user-images.githubusercontent.com/16307070/145194678-eda1d0e3-e15d-4d18-a00a-784ced7eb856.png)



### What is changed and how it works?
To solve this problem, we may launch a `raw_get` request to warm up the runtime.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to be included in the release note
