### PR TITLE
[close #370] make gRPC and TiKV health check configurable

### DIFF
--- a/src/main/java/org/tikv/common/TiConfiguration.java
+++ b/src/main/java/org/tikv/common/TiConfiguration.java
@@ -319,8 +319,8 @@ public class TiConfiguration implements Serializable {
 
   private boolean metricsEnable = getBoolean(TIKV_METRICS_ENABLE);
   private int metricsPort = getInt(TIKV_METRICS_PORT);
-  private final int grpcHealthCheckTimeout = getInt(TIKV_GRPC_HEALTH_CHECK_TIMEOUT);
-  private final int healthCheckPeriodDuration = getInt(TIKV_HEALTH_CHECK_PERIOD_DURATION);
+  private int grpcHealthCheckTimeout = getInt(TIKV_GRPC_HEALTH_CHECK_TIMEOUT);
+  private int healthCheckPeriodDuration = getInt(TIKV_HEALTH_CHECK_PERIOD_DURATION);
 
   private final String networkMappingName = get(TIKV_NETWORK_MAPPING_NAME);
   private HostMapping hostMapping = null;
@@ -690,8 +690,16 @@ public class TiConfiguration implements Serializable {
     return this.grpcHealthCheckTimeout;
   }
 
+  public void setGrpcHealthCheckTimeout(int grpcHealthCheckTimeout) {
+    this.grpcHealthCheckTimeout = grpcHealthCheckTimeout;
+  }
+
   public long getHealthCheckPeriodDuration() {
     return this.healthCheckPeriodDuration;
+  }
+
+  public void setHealthCheckPeriodDuration(int healthCheckPeriodDuration) {
+    this.healthCheckPeriodDuration = healthCheckPeriodDuration;
   }
 
   public boolean isEnableAtomicForCAS() {

--- a/src/test/java/org/tikv/common/TiConfigurationTest.java
+++ b/src/test/java/org/tikv/common/TiConfigurationTest.java
@@ -60,8 +60,9 @@ public class TiConfigurationTest {
     int newValue = 100000;
     conf.setHealthCheckPeriodDuration(newValue);
     Assert.assertEquals(newValue, conf.getHealthCheckPeriodDuration());
-   }
+  }
 
+  @Test
   public void testGrpcIdleTimeoutValue() {
     TiConfiguration conf = TiConfiguration.createDefault();
     // default value

--- a/src/test/java/org/tikv/common/TiConfigurationTest.java
+++ b/src/test/java/org/tikv/common/TiConfigurationTest.java
@@ -41,8 +41,8 @@ public class TiConfigurationTest {
   public void testGrpcHealthCheckTimeoutValue() {
     TiConfiguration conf = TiConfiguration.createDefault();
     // default value
-    Assert.assertEquals(TiConfiguration.getInt(TIKV_GRPC_HEALTH_CHECK_TIMEOUT),
-        conf.getGrpcHealthCheckTimeout());
+    Assert.assertEquals(
+        TiConfiguration.getInt(TIKV_GRPC_HEALTH_CHECK_TIMEOUT), conf.getGrpcHealthCheckTimeout());
     // new value
     int newValue = 100000;
     conf.setGrpcHealthCheckTimeout(newValue);
@@ -53,7 +53,8 @@ public class TiConfigurationTest {
   public void testHealthCheckPeriodDuration() {
     TiConfiguration conf = TiConfiguration.createDefault();
     // default value
-    Assert.assertEquals(TiConfiguration.getInt(TIKV_HEALTH_CHECK_PERIOD_DURATION),
+    Assert.assertEquals(
+        TiConfiguration.getInt(TIKV_HEALTH_CHECK_PERIOD_DURATION),
         conf.getHealthCheckPeriodDuration());
     // new value
     int newValue = 100000;

--- a/src/test/java/org/tikv/common/TiConfigurationTest.java
+++ b/src/test/java/org/tikv/common/TiConfigurationTest.java
@@ -17,7 +17,10 @@ package org.tikv.common;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.tikv.common.ConfigUtils.TIKV_GRPC_HEALTH_CHECK_TIMEOUT;
+import static org.tikv.common.ConfigUtils.TIKV_HEALTH_CHECK_PERIOD_DURATION;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 public class TiConfigurationTest {
@@ -32,5 +35,29 @@ public class TiConfigurationTest {
   public void tiFlashDefaultValueTest() {
     TiConfiguration conf = TiConfiguration.createRawDefault();
     assertFalse(conf.isTiFlashEnabled());
+  }
+
+  @Test
+  public void testGrpcHealthCheckTimeoutValue() {
+    TiConfiguration conf = TiConfiguration.createDefault();
+    // default value
+    Assert.assertEquals(TiConfiguration.getInt(TIKV_GRPC_HEALTH_CHECK_TIMEOUT),
+        conf.getGrpcHealthCheckTimeout());
+    // new value
+    int newValue = 100000;
+    conf.setGrpcHealthCheckTimeout(newValue);
+    Assert.assertEquals(newValue, conf.getGrpcHealthCheckTimeout());
+  }
+
+  @Test
+  public void testHealthCheckPeriodDuration() {
+    TiConfiguration conf = TiConfiguration.createDefault();
+    // default value
+    Assert.assertEquals(TiConfiguration.getInt(TIKV_HEALTH_CHECK_PERIOD_DURATION),
+        conf.getHealthCheckPeriodDuration());
+    // new value
+    int newValue = 100000;
+    conf.setHealthCheckPeriodDuration(newValue);
+    Assert.assertEquals(newValue, conf.getHealthCheckPeriodDuration());
   }
 }


### PR DESCRIPTION
Fix warning in OLAP engine:
```
2021-12-08 05:18:47,334 WARN  org.tikv.common.region.StoreHealthyChecker                   [] - store [tikv_host:tikv_port] is not reachable
2021-12-08 05:19:01,130 WARN  org.tikv.common.region.AbstractRegionStoreClient             [] - forward request to store [tikv_host:tikv_port] for region[174126738]
2021-12-08 05:19:01,894 WARN  org.tikv.common.region.StoreHealthyChecker                   [] - store [tikv_host:tikv_port] is not reachable
2021-12-08 05:19:01,933 WARN  org.tikv.common.region.StoreHealthyChecker                   [] - store [tikv_host:tikv_port] recovers to be reachable and canforward
2021-12-08 05:19:05,490 WARN  org.tikv.common.region.StoreHealthyChecker                   [] - store [tikv_host:tikv_port] is not reachable
2021-12-08 05:19:05,604 WARN  org.tikv.common.region.StoreHealthyChecker                   [] - store [tikv_host:tikv_port] recovers to be reachable and canforward
```
