### PR TITLE
[close #375] warm up SmartRawKVClient while creating it

### DIFF
--- a/src/main/java/org/tikv/common/TiSession.java
+++ b/src/main/java/org/tikv/common/TiSession.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,6 +54,7 @@ import org.tikv.txn.TxnKVClient;
  * thread-safe but it's also recommended to have multiple session avoiding lock contention
  */
 public class TiSession implements AutoCloseable {
+  private static final AtomicBoolean warmed = new AtomicBoolean(false);
   private static final Logger logger = LoggerFactory.getLogger(TiSession.class);
   private static final Map<String, TiSession> sessionCachedMap = new HashMap<>();
   private final TiConfiguration conf;
@@ -129,7 +131,18 @@ public class TiSession implements AutoCloseable {
 
   public SmartRawKVClient createSmartRawClient() {
     RawKVClient rawKVClient = createRawClient();
-    return new SmartRawKVClient(rawKVClient, getConf());
+    SmartRawKVClient client = new SmartRawKVClient(rawKVClient, getConf());
+
+    // Warm up SmartRawKVClient to avoid the first slow call.
+    if (warmed.compareAndSet(false, true)) {
+      try {
+        logger.info("Warming up SmartRawKVClient");
+        client.get(ByteString.EMPTY);
+      } catch (final TiKVException ignored) {
+      }
+    }
+
+    return client;
   }
 
   public KVClient createKVClient() {


### PR DESCRIPTION
Signed-off-by: iosmanthus <myosmanthustree@gmail.com>

### What problem does this PR solve? <!--add issue link with summary if exists-->

We find some initialization work that needs to do in the first gRPC call in `SmartRawKVClient` which might result in a timeout in the first few gRPC calls.

First run:

![image](https://user-images.githubusercontent.com/16307070/145193389-b5da2877-a0cd-4785-b310-19abcc68f172.png)

Second run:

![image](https://user-images.githubusercontent.com/16307070/145194678-eda1d0e3-e15d-4d18-a00a-784ced7eb856.png)



### What is changed and how it works?
To solve this problem, we may launch a `raw_get` request to warm up the runtime.
