### PR TITLE
[to #348] fix gh-pages can not deploy rendered documents

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
 
 jobs:
   deploy:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -27,4 +27,5 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
           publish_dir: ./docs/book

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -3,7 +3,7 @@ name: GitHub Pages
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
 
 jobs:
@@ -24,6 +24,7 @@ jobs:
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.ref == 'refs/heads/master' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/book

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -24,8 +24,6 @@ jobs:
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.ref == 'refs/heads/main' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: gh-pages
           publish_dir: ./docs/book


### PR DESCRIPTION
Signed-off-by: Jian Zhang <zjsariel@gmail.com>

<!-- Thank you for contributing to TiKV Java Client!

PR Title Format: "[close/to/fix #issue_number] summary" -->

### What problem does this PR solve?

Issue Number: to #348

Problem Description:
1. the generated rendered documents are not deployed in the gh-pages branch
2. the gh-pages action is configured in every pull request, but it can not deploy the rendered contents if the PR is not merged 

### What is changed and how it works?

1. change the branch name from `main` to `master`, which was a mistake made in the former PR
2. remove the action trigger condition on `pull_request`, so that the action is only triggered when the PR is merged

### Code changes

- has been tested in my personal repository

### Check List for Tests

- No code

### Side effects

- NO side effects

### Related changes

- NO related changes
