### PR TITLE
[close #49] change copyright from PingCAP to TiKV Project Authors

### DIFF
--- a/.github/license-checker.yml
+++ b/.github/license-checker.yml
@@ -1,0 +1,24 @@
+header:
+  license:
+    spdx-id: Apache-2.0
+    copyright-owner: TiKV Project Authors.
+  paths-ignore:
+    - 'config/'
+    - 'dev/'
+    - 'docs/'
+    - 'metrics/'
+    - 'scripts/'
+    - 'LICENSE'
+    - 'Makefile'
+    - 'pom.xml'
+    - 'shell.nix'
+    - '.ci/'
+    - '.gitignore'
+    - '.gitattributes'
+    - '.github/'
+    - '**/*.md'
+    - '**/*.properties'
+    - '**/*.json'
+    - '**/*.pem'
+    - '**/*.crt'
+  comment: on-failure

--- a/.github/workflows/license-checker.yml
+++ b/.github/workflows/license-checker.yml
@@ -1,0 +1,24 @@
+name: License checker
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  check-license:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Check License Header
+        uses: apache/skywalking-eyes@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          log: info
+          config: .github/license-checker.yml
+

--- a/src/main/java/org/tikv/br/BackupDecoder.java
+++ b/src/main/java/org/tikv/br/BackupDecoder.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2021 PingCAP, Inc.
+ * Copyright 2021 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/br/BackupMetaDecoder.java
+++ b/src/main/java/org/tikv/br/BackupMetaDecoder.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2021 PingCAP, Inc.
+ * Copyright 2021 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/br/KVDecoder.java
+++ b/src/main/java/org/tikv/br/KVDecoder.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2021 PingCAP, Inc.
+ * Copyright 2021 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/br/RawKVDecoderV1.java
+++ b/src/main/java/org/tikv/br/RawKVDecoderV1.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2021 PingCAP, Inc.
+ * Copyright 2021 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/br/SSTDecoder.java
+++ b/src/main/java/org/tikv/br/SSTDecoder.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2021 PingCAP, Inc.
+ * Copyright 2021 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/br/SSTIterator.java
+++ b/src/main/java/org/tikv/br/SSTIterator.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2021 PingCAP, Inc.
+ * Copyright 2021 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/AbstractGRPCClient.java
+++ b/src/main/java/org/tikv/common/AbstractGRPCClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/BytePairWrapper.java
+++ b/src/main/java/org/tikv/common/BytePairWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/ByteWrapper.java
+++ b/src/main/java/org/tikv/common/ByteWrapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/ConfigUtils.java
+++ b/src/main/java/org/tikv/common/ConfigUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 PingCAP, Inc.
+ * Copyright 2021 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/DefaultHostMapping.java
+++ b/src/main/java/org/tikv/common/DefaultHostMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 PingCAP, Inc.
+ * Copyright 2021 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/ExtendedDateTime.java
+++ b/src/main/java/org/tikv/common/ExtendedDateTime.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2019 PingCAP, Inc.
+ * Copyright 2019 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/HostMapping.java
+++ b/src/main/java/org/tikv/common/HostMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 PingCAP, Inc.
+ * Copyright 2021 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/KVClient.java
+++ b/src/main/java/org/tikv/common/KVClient.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2019 PingCAP, Inc.
+ * Copyright 2019 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/Main.java
+++ b/src/main/java/org/tikv/common/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/MetricsServer.java
+++ b/src/main/java/org/tikv/common/MetricsServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 PingCAP, Inc.
+ * Copyright 2021 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/PDClient.java
+++ b/src/main/java/org/tikv/common/PDClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/ReadOnlyPDClient.java
+++ b/src/main/java/org/tikv/common/ReadOnlyPDClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/Snapshot.java
+++ b/src/main/java/org/tikv/common/Snapshot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/StoreVersion.java
+++ b/src/main/java/org/tikv/common/StoreVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/TiBatchWriteUtils.java
+++ b/src/main/java/org/tikv/common/TiBatchWriteUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 PingCAP, Inc.
+ * Copyright 2019 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/TiConfiguration.java
+++ b/src/main/java/org/tikv/common/TiConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/TiDBJDBCClient.java
+++ b/src/main/java/org/tikv/common/TiDBJDBCClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 PingCAP, Inc.
+ * Copyright 2019 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/TiSession.java
+++ b/src/main/java/org/tikv/common/TiSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/Utils.java
+++ b/src/main/java/org/tikv/common/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 PingCAP, Inc.
+ * Copyright 2021 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/Version.java
+++ b/src/main/java/org/tikv/common/Version.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/catalog/Catalog.java
+++ b/src/main/java/org/tikv/common/catalog/Catalog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/catalog/CatalogTransaction.java
+++ b/src/main/java/org/tikv/common/catalog/CatalogTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/codec/Codec.java
+++ b/src/main/java/org/tikv/common/codec/Codec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/codec/CodecDataInput.java
+++ b/src/main/java/org/tikv/common/codec/CodecDataInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/codec/CodecDataInputLittleEndian.java
+++ b/src/main/java/org/tikv/common/codec/CodecDataInputLittleEndian.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/codec/CodecDataOutput.java
+++ b/src/main/java/org/tikv/common/codec/CodecDataOutput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/codec/CodecDataOutputLittleEndian.java
+++ b/src/main/java/org/tikv/common/codec/CodecDataOutputLittleEndian.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/codec/KeyUtils.java
+++ b/src/main/java/org/tikv/common/codec/KeyUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/codec/MetaCodec.java
+++ b/src/main/java/org/tikv/common/codec/MetaCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/codec/MyDecimal.java
+++ b/src/main/java/org/tikv/common/codec/MyDecimal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/codec/RowDecoderV2.java
+++ b/src/main/java/org/tikv/common/codec/RowDecoderV2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/codec/RowEncoderV2.java
+++ b/src/main/java/org/tikv/common/codec/RowEncoderV2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/codec/RowV2.java
+++ b/src/main/java/org/tikv/common/codec/RowV2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/codec/TableCodec.java
+++ b/src/main/java/org/tikv/common/codec/TableCodec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/codec/TableCodecV1.java
+++ b/src/main/java/org/tikv/common/codec/TableCodecV1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/codec/TableCodecV2.java
+++ b/src/main/java/org/tikv/common/codec/TableCodecV2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/columnar/BatchedTiChunkColumnVector.java
+++ b/src/main/java/org/tikv/common/columnar/BatchedTiChunkColumnVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 PingCAP, Inc.
+ * Copyright 2019 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/columnar/TiBlockColumnVector.java
+++ b/src/main/java/org/tikv/common/columnar/TiBlockColumnVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/columnar/TiChunk.java
+++ b/src/main/java/org/tikv/common/columnar/TiChunk.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 PingCAP, Inc.
+ * Copyright 2019 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/columnar/TiChunkColumnVector.java
+++ b/src/main/java/org/tikv/common/columnar/TiChunkColumnVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 PingCAP, Inc.
+ * Copyright 2019 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/columnar/TiCoreTime.java
+++ b/src/main/java/org/tikv/common/columnar/TiCoreTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/columnar/TiRowColumnVector.java
+++ b/src/main/java/org/tikv/common/columnar/TiRowColumnVector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 PingCAP, Inc.
+ * Copyright 2019 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/columnar/datatypes/AutoGrowByteBuffer.java
+++ b/src/main/java/org/tikv/common/columnar/datatypes/AutoGrowByteBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/columnar/datatypes/CHType.java
+++ b/src/main/java/org/tikv/common/columnar/datatypes/CHType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/columnar/datatypes/CHTypeDate.java
+++ b/src/main/java/org/tikv/common/columnar/datatypes/CHTypeDate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/columnar/datatypes/CHTypeDateTime.java
+++ b/src/main/java/org/tikv/common/columnar/datatypes/CHTypeDateTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/columnar/datatypes/CHTypeDecimal.java
+++ b/src/main/java/org/tikv/common/columnar/datatypes/CHTypeDecimal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/columnar/datatypes/CHTypeFixedString.java
+++ b/src/main/java/org/tikv/common/columnar/datatypes/CHTypeFixedString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/columnar/datatypes/CHTypeMyDate.java
+++ b/src/main/java/org/tikv/common/columnar/datatypes/CHTypeMyDate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/columnar/datatypes/CHTypeMyDateTime.java
+++ b/src/main/java/org/tikv/common/columnar/datatypes/CHTypeMyDateTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/columnar/datatypes/CHTypeNumber.java
+++ b/src/main/java/org/tikv/common/columnar/datatypes/CHTypeNumber.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/columnar/datatypes/CHTypeString.java
+++ b/src/main/java/org/tikv/common/columnar/datatypes/CHTypeString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/event/CacheInvalidateEvent.java
+++ b/src/main/java/org/tikv/common/event/CacheInvalidateEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/exception/AllocateRowIDOverflowException.java
+++ b/src/main/java/org/tikv/common/exception/AllocateRowIDOverflowException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/exception/CastingException.java
+++ b/src/main/java/org/tikv/common/exception/CastingException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/exception/CircuitBreakerOpenException.java
+++ b/src/main/java/org/tikv/common/exception/CircuitBreakerOpenException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 PingCAP, Inc.
+ * Copyright 2018 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/exception/CodecException.java
+++ b/src/main/java/org/tikv/common/exception/CodecException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/exception/ConvertNotSupportException.java
+++ b/src/main/java/org/tikv/common/exception/ConvertNotSupportException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 PingCAP, Inc.
+ * Copyright 2019 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/exception/ConvertOverflowException.java
+++ b/src/main/java/org/tikv/common/exception/ConvertOverflowException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 PingCAP, Inc.
+ * Copyright 2019 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/exception/DAGRequestException.java
+++ b/src/main/java/org/tikv/common/exception/DAGRequestException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/exception/GrpcException.java
+++ b/src/main/java/org/tikv/common/exception/GrpcException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/exception/IgnoreUnsupportedTypeException.java
+++ b/src/main/java/org/tikv/common/exception/IgnoreUnsupportedTypeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/exception/InvalidCodecFormatException.java
+++ b/src/main/java/org/tikv/common/exception/InvalidCodecFormatException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/exception/InvalidStoreException.java
+++ b/src/main/java/org/tikv/common/exception/InvalidStoreException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 PingCAP, Inc.
+ * Copyright 2021 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/exception/KeyException.java
+++ b/src/main/java/org/tikv/common/exception/KeyException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/exception/RawCASConflictException.java
+++ b/src/main/java/org/tikv/common/exception/RawCASConflictException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 PingCAP, Inc.
+ * Copyright 2021 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/exception/RegionException.java
+++ b/src/main/java/org/tikv/common/exception/RegionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/exception/RegionTaskException.java
+++ b/src/main/java/org/tikv/common/exception/RegionTaskException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 PingCAP, Inc.
+ * Copyright 2018 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/exception/SSTDecodeException.java
+++ b/src/main/java/org/tikv/common/exception/SSTDecodeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 PingCAP, Inc.
+ * Copyright 2021 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/exception/SelectException.java
+++ b/src/main/java/org/tikv/common/exception/SelectException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/exception/TiBatchWriteException.java
+++ b/src/main/java/org/tikv/common/exception/TiBatchWriteException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 PingCAP, Inc.
+ * Copyright 2019 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/exception/TiClientInternalException.java
+++ b/src/main/java/org/tikv/common/exception/TiClientInternalException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/exception/TiDBConvertException.java
+++ b/src/main/java/org/tikv/common/exception/TiDBConvertException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/exception/TiExpressionException.java
+++ b/src/main/java/org/tikv/common/exception/TiExpressionException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/exception/TiInternalException.java
+++ b/src/main/java/org/tikv/common/exception/TiInternalException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 PingCAP, Inc.
+ * Copyright 2019 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/exception/TiKVException.java
+++ b/src/main/java/org/tikv/common/exception/TiKVException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 PingCAP, Inc.
+ * Copyright 2018 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/exception/TypeException.java
+++ b/src/main/java/org/tikv/common/exception/TypeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/exception/UnsupportedPartitionExprException.java
+++ b/src/main/java/org/tikv/common/exception/UnsupportedPartitionExprException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/exception/UnsupportedSyntaxException.java
+++ b/src/main/java/org/tikv/common/exception/UnsupportedSyntaxException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 PingCAP, Inc.
+ * Copyright 2019 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/exception/UnsupportedTypeException.java
+++ b/src/main/java/org/tikv/common/exception/UnsupportedTypeException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/exception/WriteConflictException.java
+++ b/src/main/java/org/tikv/common/exception/WriteConflictException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/expression/AggregateFunction.java
+++ b/src/main/java/org/tikv/common/expression/AggregateFunction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/expression/ArithmeticBinaryExpression.java
+++ b/src/main/java/org/tikv/common/expression/ArithmeticBinaryExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/expression/Blocklist.java
+++ b/src/main/java/org/tikv/common/expression/Blocklist.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/expression/ByItem.java
+++ b/src/main/java/org/tikv/common/expression/ByItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/expression/ColumnRef.java
+++ b/src/main/java/org/tikv/common/expression/ColumnRef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/expression/ComparisonBinaryExpression.java
+++ b/src/main/java/org/tikv/common/expression/ComparisonBinaryExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/expression/Constant.java
+++ b/src/main/java/org/tikv/common/expression/Constant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/expression/Expression.java
+++ b/src/main/java/org/tikv/common/expression/Expression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/expression/ExpressionBlocklist.java
+++ b/src/main/java/org/tikv/common/expression/ExpressionBlocklist.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/expression/FuncCallExpr.java
+++ b/src/main/java/org/tikv/common/expression/FuncCallExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/expression/FuncCallExprEval.java
+++ b/src/main/java/org/tikv/common/expression/FuncCallExprEval.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/expression/IsNull.java
+++ b/src/main/java/org/tikv/common/expression/IsNull.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/expression/LogicalBinaryExpression.java
+++ b/src/main/java/org/tikv/common/expression/LogicalBinaryExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/expression/Not.java
+++ b/src/main/java/org/tikv/common/expression/Not.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/expression/PartitionPruner.java
+++ b/src/main/java/org/tikv/common/expression/PartitionPruner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/expression/RangeColumnPartitionPruner.java
+++ b/src/main/java/org/tikv/common/expression/RangeColumnPartitionPruner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/expression/RangePartitionPruner.java
+++ b/src/main/java/org/tikv/common/expression/RangePartitionPruner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 PingCAP, Inc.
+ * Copyright 2019 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/expression/StringRegExpression.java
+++ b/src/main/java/org/tikv/common/expression/StringRegExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/expression/TypeBlocklist.java
+++ b/src/main/java/org/tikv/common/expression/TypeBlocklist.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/expression/Visitor.java
+++ b/src/main/java/org/tikv/common/expression/Visitor.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/expression/visitor/ColumnMatcher.java
+++ b/src/main/java/org/tikv/common/expression/visitor/ColumnMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 PingCAP, Inc.
+ * Copyright 2018 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/expression/visitor/DefaultVisitor.java
+++ b/src/main/java/org/tikv/common/expression/visitor/DefaultVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/expression/visitor/IndexMatcher.java
+++ b/src/main/java/org/tikv/common/expression/visitor/IndexMatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/expression/visitor/IndexRangeSetBuilder.java
+++ b/src/main/java/org/tikv/common/expression/visitor/IndexRangeSetBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/expression/visitor/MetaResolver.java
+++ b/src/main/java/org/tikv/common/expression/visitor/MetaResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/expression/visitor/PartAndFilterExprRewriter.java
+++ b/src/main/java/org/tikv/common/expression/visitor/PartAndFilterExprRewriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/expression/visitor/ProtoConverter.java
+++ b/src/main/java/org/tikv/common/expression/visitor/ProtoConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/expression/visitor/PrunedPartitionBuilder.java
+++ b/src/main/java/org/tikv/common/expression/visitor/PrunedPartitionBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 PingCAP, Inc.
+ * Copyright 2019 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/expression/visitor/PseudoCostCalculator.java
+++ b/src/main/java/org/tikv/common/expression/visitor/PseudoCostCalculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/expression/visitor/RangeSetBuilder.java
+++ b/src/main/java/org/tikv/common/expression/visitor/RangeSetBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 PingCAP, Inc.
+ * Copyright 2019 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/expression/visitor/SupportedExpressionValidator.java
+++ b/src/main/java/org/tikv/common/expression/visitor/SupportedExpressionValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/importer/ImporterClient.java
+++ b/src/main/java/org/tikv/common/importer/ImporterClient.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2021 PingCAP, Inc.
+ * Copyright 2021 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/importer/ImporterStoreClient.java
+++ b/src/main/java/org/tikv/common/importer/ImporterStoreClient.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2021 PingCAP, Inc.
+ * Copyright 2021 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/importer/SwitchTiKVModeClient.java
+++ b/src/main/java/org/tikv/common/importer/SwitchTiKVModeClient.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2021 PingCAP, Inc.
+ * Copyright 2021 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/key/CompoundKey.java
+++ b/src/main/java/org/tikv/common/key/CompoundKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/key/IndexKey.java
+++ b/src/main/java/org/tikv/common/key/IndexKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/key/IndexScanKeyRangeBuilder.java
+++ b/src/main/java/org/tikv/common/key/IndexScanKeyRangeBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 PingCAP, Inc.
+ * Copyright 2019 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/key/Key.java
+++ b/src/main/java/org/tikv/common/key/Key.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/key/KeyRangeBuilder.java
+++ b/src/main/java/org/tikv/common/key/KeyRangeBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 PingCAP, Inc.
+ * Copyright 2019 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/key/RowKey.java
+++ b/src/main/java/org/tikv/common/key/RowKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/key/StatisticsKeyRangeBuilder.java
+++ b/src/main/java/org/tikv/common/key/StatisticsKeyRangeBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 PingCAP, Inc.
+ * Copyright 2019 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/key/TypedKey.java
+++ b/src/main/java/org/tikv/common/key/TypedKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/log/SlowLog.java
+++ b/src/main/java/org/tikv/common/log/SlowLog.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2021 PingCAP, Inc.
+ * Copyright 2021 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/log/SlowLogEmptyImpl.java
+++ b/src/main/java/org/tikv/common/log/SlowLogEmptyImpl.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2021 PingCAP, Inc.
+ * Copyright 2021 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/log/SlowLogImpl.java
+++ b/src/main/java/org/tikv/common/log/SlowLogImpl.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2021 PingCAP, Inc.
+ * Copyright 2021 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/log/SlowLogSpan.java
+++ b/src/main/java/org/tikv/common/log/SlowLogSpan.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2021 PingCAP, Inc.
+ * Copyright 2021 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/log/SlowLogSpanEmptyImpl.java
+++ b/src/main/java/org/tikv/common/log/SlowLogSpanEmptyImpl.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2021 PingCAP, Inc.
+ * Copyright 2021 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/log/SlowLogSpanImpl.java
+++ b/src/main/java/org/tikv/common/log/SlowLogSpanImpl.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2021 PingCAP, Inc.
+ * Copyright 2021 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/meta/CIStr.java
+++ b/src/main/java/org/tikv/common/meta/CIStr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/meta/Collation.java
+++ b/src/main/java/org/tikv/common/meta/Collation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/meta/IndexType.java
+++ b/src/main/java/org/tikv/common/meta/IndexType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/meta/SchemaState.java
+++ b/src/main/java/org/tikv/common/meta/SchemaState.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/meta/TiColumnInfo.java
+++ b/src/main/java/org/tikv/common/meta/TiColumnInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/meta/TiDAGRequest.java
+++ b/src/main/java/org/tikv/common/meta/TiDAGRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/meta/TiDBInfo.java
+++ b/src/main/java/org/tikv/common/meta/TiDBInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/meta/TiFlashReplicaInfo.java
+++ b/src/main/java/org/tikv/common/meta/TiFlashReplicaInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/meta/TiIndexColumn.java
+++ b/src/main/java/org/tikv/common/meta/TiIndexColumn.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/meta/TiIndexInfo.java
+++ b/src/main/java/org/tikv/common/meta/TiIndexInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/meta/TiPartitionDef.java
+++ b/src/main/java/org/tikv/common/meta/TiPartitionDef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 PingCAP, Inc.
+ * Copyright 2018 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/meta/TiPartitionExpr.java
+++ b/src/main/java/org/tikv/common/meta/TiPartitionExpr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 PingCAP, Inc.
+ * Copyright 2018 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/meta/TiPartitionInfo.java
+++ b/src/main/java/org/tikv/common/meta/TiPartitionInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 PingCAP, Inc.
+ * Copyright 2018 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/meta/TiSequenceInfo.java
+++ b/src/main/java/org/tikv/common/meta/TiSequenceInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/meta/TiTableInfo.java
+++ b/src/main/java/org/tikv/common/meta/TiTableInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/meta/TiTimestamp.java
+++ b/src/main/java/org/tikv/common/meta/TiTimestamp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/meta/TiUserIdentity.java
+++ b/src/main/java/org/tikv/common/meta/TiUserIdentity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/meta/TiViewInfo.java
+++ b/src/main/java/org/tikv/common/meta/TiViewInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/operation/ErrorHandler.java
+++ b/src/main/java/org/tikv/common/operation/ErrorHandler.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/operation/KVErrorHandler.java
+++ b/src/main/java/org/tikv/common/operation/KVErrorHandler.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/operation/NoopHandler.java
+++ b/src/main/java/org/tikv/common/operation/NoopHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 PingCAP, Inc.
+ * Copyright 2019 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/operation/PDErrorHandler.java
+++ b/src/main/java/org/tikv/common/operation/PDErrorHandler.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/operation/SchemaInfer.java
+++ b/src/main/java/org/tikv/common/operation/SchemaInfer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/operation/iterator/ChunkIterator.java
+++ b/src/main/java/org/tikv/common/operation/iterator/ChunkIterator.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/operation/iterator/ConcreteScanIterator.java
+++ b/src/main/java/org/tikv/common/operation/iterator/ConcreteScanIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 PingCAP, Inc.
+ * Copyright 2018 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/operation/iterator/CoprocessorIterator.java
+++ b/src/main/java/org/tikv/common/operation/iterator/CoprocessorIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/operation/iterator/DAGIterator.java
+++ b/src/main/java/org/tikv/common/operation/iterator/DAGIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/operation/iterator/IndexScanIterator.java
+++ b/src/main/java/org/tikv/common/operation/iterator/IndexScanIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/operation/iterator/RawScanIterator.java
+++ b/src/main/java/org/tikv/common/operation/iterator/RawScanIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/operation/iterator/ScanIterator.java
+++ b/src/main/java/org/tikv/common/operation/iterator/ScanIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 PingCAP, Inc.
+ * Copyright 2018 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/parser/AstBuilder.java
+++ b/src/main/java/org/tikv/common/parser/AstBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/parser/CaseChangingCharStream.java
+++ b/src/main/java/org/tikv/common/parser/CaseChangingCharStream.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2019 PingCAP, Inc.
+ * Copyright 2019 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/parser/TiParser.java
+++ b/src/main/java/org/tikv/common/parser/TiParser.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2019 PingCAP, Inc.
+ * Copyright 2019 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/pd/PDError.java
+++ b/src/main/java/org/tikv/common/pd/PDError.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2018 PingCAP, Inc.
+ * Copyright 2018 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/pd/PDUtils.java
+++ b/src/main/java/org/tikv/common/pd/PDUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 PingCAP, Inc.
+ * Copyright 2019 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/policy/RetryMaxMs.java
+++ b/src/main/java/org/tikv/common/policy/RetryMaxMs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/policy/RetryPolicy.java
+++ b/src/main/java/org/tikv/common/policy/RetryPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/predicates/IndexRange.java
+++ b/src/main/java/org/tikv/common/predicates/IndexRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/predicates/PredicateUtils.java
+++ b/src/main/java/org/tikv/common/predicates/PredicateUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/predicates/ScanSpec.java
+++ b/src/main/java/org/tikv/common/predicates/ScanSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/predicates/SelectivityCalculator.java
+++ b/src/main/java/org/tikv/common/predicates/SelectivityCalculator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/predicates/TiKVScanAnalyzer.java
+++ b/src/main/java/org/tikv/common/predicates/TiKVScanAnalyzer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/region/AbstractRegionStoreClient.java
+++ b/src/main/java/org/tikv/common/region/AbstractRegionStoreClient.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2019 PingCAP, Inc.
+ * Copyright 2019 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/region/RegionErrorReceiver.java
+++ b/src/main/java/org/tikv/common/region/RegionErrorReceiver.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/region/RegionManager.java
+++ b/src/main/java/org/tikv/common/region/RegionManager.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/region/RegionStoreClient.java
+++ b/src/main/java/org/tikv/common/region/RegionStoreClient.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/region/TiRegion.java
+++ b/src/main/java/org/tikv/common/region/TiRegion.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/region/TiStoreType.java
+++ b/src/main/java/org/tikv/common/region/TiStoreType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/replica/FollowerReplicaSelector.java
+++ b/src/main/java/org/tikv/common/replica/FollowerReplicaSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 PingCAP, Inc.
+ * Copyright 2021 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/replica/LeaderFollowerReplicaSelector.java
+++ b/src/main/java/org/tikv/common/replica/LeaderFollowerReplicaSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 PingCAP, Inc.
+ * Copyright 2021 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/replica/LeaderReplicaSelector.java
+++ b/src/main/java/org/tikv/common/replica/LeaderReplicaSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 PingCAP, Inc.
+ * Copyright 2021 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/replica/ReplicaSelector.java
+++ b/src/main/java/org/tikv/common/replica/ReplicaSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 PingCAP, Inc.
+ * Copyright 2021 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/row/DefaultRowReader.java
+++ b/src/main/java/org/tikv/common/row/DefaultRowReader.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/row/ObjectRowImpl.java
+++ b/src/main/java/org/tikv/common/row/ObjectRowImpl.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/row/Row.java
+++ b/src/main/java/org/tikv/common/row/Row.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/row/RowReader.java
+++ b/src/main/java/org/tikv/common/row/RowReader.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/row/RowReaderFactory.java
+++ b/src/main/java/org/tikv/common/row/RowReaderFactory.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/statistics/Bucket.java
+++ b/src/main/java/org/tikv/common/statistics/Bucket.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2018 PingCAP, Inc.
+ * Copyright 2018 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/statistics/CMSketch.java
+++ b/src/main/java/org/tikv/common/statistics/CMSketch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 PingCAP, Inc.
+ * Copyright 2018 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/statistics/ColumnStatistics.java
+++ b/src/main/java/org/tikv/common/statistics/ColumnStatistics.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2018 PingCAP, Inc.
+ * Copyright 2018 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/statistics/Histogram.java
+++ b/src/main/java/org/tikv/common/statistics/Histogram.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 PingCAP, Inc.
+ * Copyright 2018 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/statistics/IndexStatistics.java
+++ b/src/main/java/org/tikv/common/statistics/IndexStatistics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 PingCAP, Inc.
+ * Copyright 2018 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/statistics/TableStatistics.java
+++ b/src/main/java/org/tikv/common/statistics/TableStatistics.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2018 PingCAP, Inc.
+ * Copyright 2018 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/streaming/StreamingResponse.java
+++ b/src/main/java/org/tikv/common/streaming/StreamingResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/types/AbstractDateTimeType.java
+++ b/src/main/java/org/tikv/common/types/AbstractDateTimeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/types/BitType.java
+++ b/src/main/java/org/tikv/common/types/BitType.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/types/BytesType.java
+++ b/src/main/java/org/tikv/common/types/BytesType.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/types/Charset.java
+++ b/src/main/java/org/tikv/common/types/Charset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/types/Converter.java
+++ b/src/main/java/org/tikv/common/types/Converter.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/types/DataType.java
+++ b/src/main/java/org/tikv/common/types/DataType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/types/DataTypeFactory.java
+++ b/src/main/java/org/tikv/common/types/DataTypeFactory.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/types/DateTimeType.java
+++ b/src/main/java/org/tikv/common/types/DateTimeType.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/types/DateType.java
+++ b/src/main/java/org/tikv/common/types/DateType.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/types/DecimalType.java
+++ b/src/main/java/org/tikv/common/types/DecimalType.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/types/EnumType.java
+++ b/src/main/java/org/tikv/common/types/EnumType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/types/IntegerType.java
+++ b/src/main/java/org/tikv/common/types/IntegerType.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/types/JsonType.java
+++ b/src/main/java/org/tikv/common/types/JsonType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/types/MySQLType.java
+++ b/src/main/java/org/tikv/common/types/MySQLType.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/types/RealType.java
+++ b/src/main/java/org/tikv/common/types/RealType.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/types/SetType.java
+++ b/src/main/java/org/tikv/common/types/SetType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/types/StringType.java
+++ b/src/main/java/org/tikv/common/types/StringType.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/types/TimeType.java
+++ b/src/main/java/org/tikv/common/types/TimeType.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/types/TimestampType.java
+++ b/src/main/java/org/tikv/common/types/TimestampType.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/types/UninitializedType.java
+++ b/src/main/java/org/tikv/common/types/UninitializedType.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2019 PingCAP, Inc.
+ * Copyright 2019 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/util/BackOffer.java
+++ b/src/main/java/org/tikv/common/util/BackOffer.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/util/Batch.java
+++ b/src/main/java/org/tikv/common/util/Batch.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 PingCAP, Inc.
+ * Copyright 2021 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/util/CHTypeMapping.java
+++ b/src/main/java/org/tikv/common/util/CHTypeMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/util/ChannelFactory.java
+++ b/src/main/java/org/tikv/common/util/ChannelFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/util/ClientUtils.java
+++ b/src/main/java/org/tikv/common/util/ClientUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 PingCAP, Inc.
+ * Copyright 2021 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/util/ConcreteBackOffer.java
+++ b/src/main/java/org/tikv/common/util/ConcreteBackOffer.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/util/DeleteRange.java
+++ b/src/main/java/org/tikv/common/util/DeleteRange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 PingCAP, Inc.
+ * Copyright 2021 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/util/FutureObserver.java
+++ b/src/main/java/org/tikv/common/util/FutureObserver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/util/JsonUtils.java
+++ b/src/main/java/org/tikv/common/util/JsonUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/util/KeyRangeUtils.java
+++ b/src/main/java/org/tikv/common/util/KeyRangeUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/util/MemoryUtil.java
+++ b/src/main/java/org/tikv/common/util/MemoryUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/util/Pair.java
+++ b/src/main/java/org/tikv/common/util/Pair.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/util/RangeSplitter.java
+++ b/src/main/java/org/tikv/common/util/RangeSplitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/util/ScanOption.java
+++ b/src/main/java/org/tikv/common/util/ScanOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/util/Timer.java
+++ b/src/main/java/org/tikv/common/util/Timer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/common/util/TsoUtils.java
+++ b/src/main/java/org/tikv/common/util/TsoUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/raw/RawKVClient.java
+++ b/src/main/java/org/tikv/raw/RawKVClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 PingCAP, Inc.
+ * Copyright 2018 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/raw/RawKVClientBase.java
+++ b/src/main/java/org/tikv/raw/RawKVClientBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 PingCAP, Inc.
+ * Copyright 2021 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/raw/SmartRawKVClient.java
+++ b/src/main/java/org/tikv/raw/SmartRawKVClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 PingCAP, Inc.
+ * Copyright 2021 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/service/failsafe/CircuitBreaker.java
+++ b/src/main/java/org/tikv/service/failsafe/CircuitBreaker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 PingCAP, Inc.
+ * Copyright 2021 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/service/failsafe/CircuitBreakerImpl.java
+++ b/src/main/java/org/tikv/service/failsafe/CircuitBreakerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 PingCAP, Inc.
+ * Copyright 2021 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/service/failsafe/CircuitBreakerMetrics.java
+++ b/src/main/java/org/tikv/service/failsafe/CircuitBreakerMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 PingCAP, Inc.
+ * Copyright 2021 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/service/failsafe/CircuitBreakerMetricsImpl.java
+++ b/src/main/java/org/tikv/service/failsafe/CircuitBreakerMetricsImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 PingCAP, Inc.
+ * Copyright 2021 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/service/failsafe/HealthCounts.java
+++ b/src/main/java/org/tikv/service/failsafe/HealthCounts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 PingCAP, Inc.
+ * Copyright 2021 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/service/failsafe/MetricsListener.java
+++ b/src/main/java/org/tikv/service/failsafe/MetricsListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 PingCAP, Inc.
+ * Copyright 2021 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/service/failsafe/NoOpCircuitBreakerMetrics.java
+++ b/src/main/java/org/tikv/service/failsafe/NoOpCircuitBreakerMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 PingCAP, Inc.
+ * Copyright 2021 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/txn/AbstractLockResolverClient.java
+++ b/src/main/java/org/tikv/txn/AbstractLockResolverClient.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/txn/KVClient.java
+++ b/src/main/java/org/tikv/txn/KVClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/txn/Lock.java
+++ b/src/main/java/org/tikv/txn/Lock.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/txn/LockResolverClientV2.java
+++ b/src/main/java/org/tikv/txn/LockResolverClientV2.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/txn/LockResolverClientV3.java
+++ b/src/main/java/org/tikv/txn/LockResolverClientV3.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/txn/LockResolverClientV4.java
+++ b/src/main/java/org/tikv/txn/LockResolverClientV4.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/txn/ResolveLockResult.java
+++ b/src/main/java/org/tikv/txn/ResolveLockResult.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/txn/TTLManager.java
+++ b/src/main/java/org/tikv/txn/TTLManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/txn/TwoPhaseCommitter.java
+++ b/src/main/java/org/tikv/txn/TwoPhaseCommitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/txn/TxnExpireTime.java
+++ b/src/main/java/org/tikv/txn/TxnExpireTime.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/txn/TxnKVClient.java
+++ b/src/main/java/org/tikv/txn/TxnKVClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 PingCAP, Inc.
+ * Copyright 2019 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/txn/TxnStatus.java
+++ b/src/main/java/org/tikv/txn/TxnStatus.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/txn/exception/LockException.java
+++ b/src/main/java/org/tikv/txn/exception/LockException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/txn/exception/TxnNotFoundException.java
+++ b/src/main/java/org/tikv/txn/exception/TxnNotFoundException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/txn/exception/WriteConflictException.java
+++ b/src/main/java/org/tikv/txn/exception/WriteConflictException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/txn/type/BatchKeys.java
+++ b/src/main/java/org/tikv/txn/type/BatchKeys.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/tikv/txn/type/GroupKeyResult.java
+++ b/src/main/java/org/tikv/txn/type/GroupKeyResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/tikv/common/GrpcUtils.java
+++ b/src/test/java/org/tikv/common/GrpcUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/tikv/common/KVMockServer.java
+++ b/src/test/java/org/tikv/common/KVMockServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/tikv/common/PDClientMockTest.java
+++ b/src/test/java/org/tikv/common/PDClientMockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/tikv/common/PDMockServer.java
+++ b/src/test/java/org/tikv/common/PDMockServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/tikv/common/PDMockServerTest.java
+++ b/src/test/java/org/tikv/common/PDMockServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 PingCAP, Inc.
+ * Copyright 2020 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/tikv/common/RegionManagerTest.java
+++ b/src/test/java/org/tikv/common/RegionManagerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/tikv/common/RegionStoreClientTest.java
+++ b/src/test/java/org/tikv/common/RegionStoreClientTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/tikv/common/TiConfigurationTest.java
+++ b/src/test/java/org/tikv/common/TiConfigurationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 PingCAP, Inc.
+ * Copyright 2021 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/tikv/common/codec/CodecTest.java
+++ b/src/test/java/org/tikv/common/codec/CodecTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/tikv/common/codec/MyDecimalTest.java
+++ b/src/test/java/org/tikv/common/codec/MyDecimalTest.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/java/org/tikv/common/key/KeyTest.java
+++ b/src/test/java/org/tikv/common/key/KeyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 PingCAP, Inc.
+ * Copyright 2017 TiKV Project Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Signed-off-by: Jian Zhang <zjsariel@gmail.com>

<!-- Thank you for contributing to TiKV Java Client!

PR Title Format: "[close/to/fix #issue_number] summary" -->

### What problem does this PR solve?

Issue Number: close #49, close #194

Problem Description: the copyright is PingCAP at present, should be TiKV project authors.

### What is changed and how it works?

Change copyright from PingCAP to TiKV Project Authors. All the changes are made by the following shell script:

```sh
find src -name "*.java" | xargs sed -i "s/PingCAP, Inc/TiKV Project Authors/"
```

### Code changes

<!-- REMOVE the items that are not applicable -->

- No code

### Check List for Tests

This PR has been tested by the at least one of the following methods:

- No code

### Side effects

<!-- REMOVE the items that are not applicable -->

- NO side effects

### Related changes

<!-- REMOVE the items that are not applicable -->
- Need to cherry-pick to the release branch
