### PR TITLE
[close #433] fix calling getStoreById without backoffer

### DIFF
--- a/src/main/java/org/tikv/common/operation/RegionErrorHandler.java
+++ b/src/main/java/org/tikv/common/operation/RegionErrorHandler.java
@@ -76,7 +76,7 @@ public class RegionErrorHandler<RespT> implements ErrorHandler<RespT> {
         // onNotLeader is only needed when updateLeader succeeds, thus switch
         // to a new store address.
         TiRegion newRegion = this.regionManager.updateLeader(recv.getRegion(), newStoreId);
-        retry = newRegion != null && recv.onNotLeader(newRegion);
+        retry = newRegion != null && recv.onNotLeader(newRegion, backOffer);
 
         backOffFuncType = BackOffFunction.BackOffFuncType.BoUpdateLeader;
       } else {

--- a/src/main/java/org/tikv/common/region/AbstractRegionStoreClient.java
+++ b/src/main/java/org/tikv/common/region/AbstractRegionStoreClient.java
@@ -108,7 +108,7 @@ public abstract class AbstractRegionStoreClient
    * @return false when re-split is needed.
    */
   @Override
-  public boolean onNotLeader(TiRegion newRegion) {
+  public boolean onNotLeader(TiRegion newRegion, BackOffer backOffer) {
     if (logger.isDebugEnabled()) {
       logger.debug(region + ", new leader = " + newRegion.getLeader().getStoreId());
     }
@@ -123,7 +123,7 @@ public abstract class AbstractRegionStoreClient
       store = null;
     }
     region = newRegion;
-    store = regionManager.getStoreById(region.getLeader().getStoreId());
+    store = regionManager.getStoreById(region.getLeader().getStoreId(), backOffer);
     updateClientStub();
     return true;
   }
@@ -193,10 +193,10 @@ public abstract class AbstractRegionStoreClient
 
       logger.info(String.format("try switch leader: region[%d]", region.getId()));
 
-      Metapb.Peer peer = switchLeaderStore();
+      Metapb.Peer peer = switchLeaderStore(backOffer);
       if (peer != null) {
         // we found a leader
-        TiStore currentLeaderStore = regionManager.getStoreById(peer.getStoreId());
+        TiStore currentLeaderStore = regionManager.getStoreById(peer.getStoreId(), backOffer);
         if (currentLeaderStore.isReachable()) {
           logger.info(
               String.format(
@@ -232,7 +232,7 @@ public abstract class AbstractRegionStoreClient
     try {
       logger.info(String.format("try grpc forward: region[%d]", region.getId()));
       // when current leader cannot be reached
-      TiStore storeWithProxy = switchProxyStore();
+      TiStore storeWithProxy = switchProxyStore(backOffer);
       if (storeWithProxy == null) {
         // no store available, retry
         logger.warn(String.format("No store available, retry: region[%d]", region.getId()));
@@ -250,11 +250,11 @@ public abstract class AbstractRegionStoreClient
   }
 
   // first: leader peer, second: true if any responses returned with grpc error
-  private Metapb.Peer switchLeaderStore() {
+  private Metapb.Peer switchLeaderStore(BackOffer backOffer) {
     List<SwitchLeaderTask> responses = new LinkedList<>();
     for (Metapb.Peer peer : region.getFollowerList()) {
       ByteString key = region.getStartKey();
-      TiStore peerStore = regionManager.getStoreById(peer.getStoreId());
+      TiStore peerStore = regionManager.getStoreById(peer.getStoreId(), backOffer);
       ManagedChannel channel =
           channelFactory.getChannel(
               peerStore.getAddress(), regionManager.getPDClient().getHostMapping());
@@ -300,12 +300,12 @@ public abstract class AbstractRegionStoreClient
     }
   }
 
-  private TiStore switchProxyStore() {
+  private TiStore switchProxyStore(BackOffer backOffer) {
     long forwardTimeout = conf.getForwardTimeout();
     List<ForwardCheckTask> responses = new LinkedList<>();
     for (Metapb.Peer peer : region.getFollowerList()) {
       ByteString key = region.getStartKey();
-      TiStore peerStore = regionManager.getStoreById(peer.getStoreId());
+      TiStore peerStore = regionManager.getStoreById(peer.getStoreId(), backOffer);
       ManagedChannel channel =
           channelFactory.getChannel(
               peerStore.getAddress(), regionManager.getPDClient().getHostMapping());

--- a/src/main/java/org/tikv/common/region/RegionErrorReceiver.java
+++ b/src/main/java/org/tikv/common/region/RegionErrorReceiver.java
@@ -20,7 +20,7 @@ package org.tikv.common.region;
 import org.tikv.common.util.BackOffer;
 
 public interface RegionErrorReceiver {
-  boolean onNotLeader(TiRegion region);
+  boolean onNotLeader(TiRegion region, BackOffer backOffer);
 
   /// return whether we need to retry this request.
   boolean onStoreUnreachable(BackOffer backOffer);

--- a/src/main/java/org/tikv/common/region/RegionManager.java
+++ b/src/main/java/org/tikv/common/region/RegionManager.java
@@ -254,18 +254,13 @@ public class RegionManager {
   }
 
   public TiStore getStoreById(long id, BackOffer backOffer) {
-    SlowLogSpan span = backOffer.getSlowLog().start("getStoreById");
-    try {
-      TiStore store = getStoreByIdWithBackOff(id, backOffer);
-      if (store == null) {
-        logger.warn(String.format("failed to fetch store %d, the store may be missing", id));
-        cache.clearAll();
-        throw new InvalidStoreException(id);
-      }
-      return store;
-    } finally {
-      span.end();
+    TiStore store = getStoreByIdWithBackOff(id, backOffer);
+    if (store == null) {
+      logger.warn(String.format("failed to fetch store %d, the store may be missing", id));
+      cache.clearAll();
+      throw new InvalidStoreException(id);
     }
+    return store;
   }
 
   public void onRegionStale(TiRegion region) {

--- a/src/main/java/org/tikv/common/region/RegionManager.java
+++ b/src/main/java/org/tikv/common/region/RegionManager.java
@@ -254,13 +254,18 @@ public class RegionManager {
   }
 
   public TiStore getStoreById(long id, BackOffer backOffer) {
-    TiStore store = getStoreByIdWithBackOff(id, backOffer);
-    if (store == null) {
-      logger.warn(String.format("failed to fetch store %d, the store may be missing", id));
-      cache.clearAll();
-      throw new InvalidStoreException(id);
+    SlowLogSpan span = backOffer.getSlowLog().start("getStoreById");
+    try {
+      TiStore store = getStoreByIdWithBackOff(id, backOffer);
+      if (store == null) {
+        logger.warn(String.format("failed to fetch store %d, the store may be missing", id));
+        cache.clearAll();
+        throw new InvalidStoreException(id);
+      }
+      return store;
+    } finally {
+      span.end();
     }
-    return store;
   }
 
   public void onRegionStale(TiRegion region) {

--- a/src/main/java/org/tikv/common/region/RegionStoreClient.java
+++ b/src/main/java/org/tikv/common/region/RegionStoreClient.java
@@ -274,7 +274,7 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
     boolean forWrite = false;
     while (true) {
       // we should refresh region
-      region = regionManager.getRegionByKey(startKey);
+      region = regionManager.getRegionByKey(startKey, backOffer);
 
       Supplier<ScanRequest> request =
           () ->

--- a/src/main/java/org/tikv/common/util/ConcreteBackOffer.java
+++ b/src/main/java/org/tikv/common/util/ConcreteBackOffer.java
@@ -168,8 +168,6 @@ public class ConcreteBackOffer implements BackOffer {
   }
 
   public boolean canRetryAfterSleep(BackOffFunction.BackOffFuncType funcType, long maxSleepMs) {
-    SlowLogSpan slowLogSpan = getSlowLog().start("backoff " + funcType.name());
-    Histogram.Timer backOffTimer = BACKOFF_DURATION.labels(funcType.name()).startTimer();
     BackOffFunction backOffFunction =
         backOffFunctionMap.computeIfAbsent(funcType, this::createBackOffFunc);
 
@@ -185,6 +183,8 @@ public class ConcreteBackOffer implements BackOffer {
       }
     }
 
+    Histogram.Timer backOffTimer = BACKOFF_DURATION.labels(funcType.name()).startTimer();
+    SlowLogSpan slowLogSpan = getSlowLog().start("backoff " + funcType.name());
     try {
       Thread.sleep(sleep);
     } catch (InterruptedException e) {

--- a/src/test/java/org/tikv/BaseRawKVTest.java
+++ b/src/test/java/org/tikv/BaseRawKVTest.java
@@ -14,6 +14,7 @@ public class BaseRawKVTest {
     conf.setTest(true);
     conf.setEnableAtomicForCAS(true);
     conf.setEnableGrpcForward(false);
+    conf.setEnableAtomicForCAS(true);
     return conf;
   }
 }


### PR DESCRIPTION
close #433

Timeout in seekLeaderStore is not limited.

We should use `backoffer` for all the gRPC calls.