### PR TITLE
[close #446] Fix Optional fields type

### DIFF
--- a/src/main/java/org/tikv/common/TiConfiguration.java
+++ b/src/main/java/org/tikv/common/TiConfiguration.java
@@ -360,12 +360,12 @@ public class TiConfiguration implements Serializable {
   private int rawKVBatchWriteTimeoutInMS = getInt(TIKV_RAWKV_BATCH_WRITE_TIMEOUT_IN_MS);
   private int rawKVScanTimeoutInMS = getInt(TIKV_RAWKV_SCAN_TIMEOUT_IN_MS);
   private int rawKVCleanTimeoutInMS = getInt(TIKV_RAWKV_CLEAN_TIMEOUT_IN_MS);
-  private Optional<Integer> rawKVReadSlowLogInMS = getIntOption(TIKV_RAWKV_READ_SLOWLOG_IN_MS);
-  private Optional<Integer> rawKVWriteSlowLogInMS = getIntOption(TIKV_RAWKV_WRITE_SLOWLOG_IN_MS);
-  private Optional<Integer> rawKVBatchReadSlowLogInMS =
-      getIntOption(TIKV_RAWKV_BATCH_READ_SLOWLOG_IN_MS);
-  private Optional<Integer> rawKVBatchWriteSlowLogInMS =
-      getIntOption(TIKV_RAWKV_BATCH_WRITE_SLOWLOG_IN_MS);
+  private Integer rawKVReadSlowLogInMS = getIntOption(TIKV_RAWKV_READ_SLOWLOG_IN_MS).orElse(null);
+  private Integer rawKVWriteSlowLogInMS = getIntOption(TIKV_RAWKV_WRITE_SLOWLOG_IN_MS).orElse(null);
+  private Integer rawKVBatchReadSlowLogInMS =
+      getIntOption(TIKV_RAWKV_BATCH_READ_SLOWLOG_IN_MS).orElse(null);
+  private Integer rawKVBatchWriteSlowLogInMS =
+      getIntOption(TIKV_RAWKV_BATCH_WRITE_SLOWLOG_IN_MS).orElse(null);
   private int rawKVScanSlowLogInMS = getInt(TIKV_RAWKV_SCAN_SLOWLOG_IN_MS);
 
   private boolean tlsEnable = getBoolean(TIKV_TLS_ENABLE);
@@ -956,35 +956,35 @@ public class TiConfiguration implements Serializable {
   }
 
   public Integer getRawKVReadSlowLogInMS() {
-    return rawKVReadSlowLogInMS.orElse((int) (getTimeout() * 2));
+    return Optional.ofNullable(rawKVReadSlowLogInMS).orElse((int) (getTimeout() * 2));
   }
 
   public void setRawKVReadSlowLogInMS(Integer rawKVReadSlowLogInMS) {
-    this.rawKVReadSlowLogInMS = Optional.of(rawKVReadSlowLogInMS);
+    this.rawKVReadSlowLogInMS = rawKVReadSlowLogInMS;
   }
 
   public Integer getRawKVWriteSlowLogInMS() {
-    return rawKVWriteSlowLogInMS.orElse((int) (getTimeout() * 2));
+    return Optional.ofNullable(rawKVWriteSlowLogInMS).orElse((int) (getTimeout() * 2));
   }
 
   public void setRawKVWriteSlowLogInMS(Integer rawKVWriteSlowLogInMS) {
-    this.rawKVWriteSlowLogInMS = Optional.of(rawKVWriteSlowLogInMS);
+    this.rawKVWriteSlowLogInMS = rawKVWriteSlowLogInMS;
   }
 
   public Integer getRawKVBatchReadSlowLogInMS() {
-    return rawKVBatchReadSlowLogInMS.orElse((int) (getTimeout() * 2));
+    return Optional.ofNullable(rawKVBatchReadSlowLogInMS).orElse((int) (getTimeout() * 2));
   }
 
   public void setRawKVBatchReadSlowLogInMS(Integer rawKVBatchReadSlowLogInMS) {
-    this.rawKVBatchReadSlowLogInMS = Optional.of(rawKVBatchReadSlowLogInMS);
+    this.rawKVBatchReadSlowLogInMS = rawKVBatchReadSlowLogInMS;
   }
 
   public Integer getRawKVBatchWriteSlowLogInMS() {
-    return rawKVBatchWriteSlowLogInMS.orElse((int) (getTimeout() * 2));
+    return Optional.ofNullable(rawKVBatchWriteSlowLogInMS).orElse((int) (getTimeout() * 2));
   }
 
   public void setRawKVBatchWriteSlowLogInMS(Integer rawKVBatchWriteSlowLogInMS) {
-    this.rawKVBatchWriteSlowLogInMS = Optional.of(rawKVBatchWriteSlowLogInMS);
+    this.rawKVBatchWriteSlowLogInMS = rawKVBatchWriteSlowLogInMS;
   }
 
   public int getRawKVScanSlowLogInMS() {

--- a/src/test/java/org/tikv/common/TiConfigurationTest.java
+++ b/src/test/java/org/tikv/common/TiConfigurationTest.java
@@ -20,6 +20,9 @@ import static org.junit.Assert.assertFalse;
 import static org.tikv.common.ConfigUtils.TIKV_GRPC_HEALTH_CHECK_TIMEOUT;
 import static org.tikv.common.ConfigUtils.TIKV_HEALTH_CHECK_PERIOD_DURATION;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -77,5 +80,24 @@ public class TiConfigurationTest {
   public void tiJksDefaultValueTest() {
     TiConfiguration conf = TiConfiguration.createRawDefault();
     assertFalse(conf.isJksEnable());
+  }
+
+  @Test
+  public void slowLogDefaultValueTest() {
+    TiConfiguration conf = TiConfiguration.createRawDefault();
+    assertEquals(conf.getTimeout() * 2, conf.getRawKVReadSlowLogInMS().longValue());
+    assertEquals(conf.getTimeout() * 2, conf.getRawKVWriteSlowLogInMS().longValue());
+    assertEquals(conf.getTimeout() * 2, conf.getRawKVBatchReadSlowLogInMS().longValue());
+    assertEquals(conf.getTimeout() * 2, conf.getRawKVBatchWriteSlowLogInMS().longValue());
+  }
+
+  @Test
+  public void serializeTest() throws IOException {
+    TiConfiguration conf = TiConfiguration.createDefault();
+    try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+      oos.writeObject(conf);
+      oos.flush();
+    }
   }
 }


### PR DESCRIPTION
Signed-off-by: Qishang Zhong <zhongqishang@gmail.com>

### What problem does this PR solve?

When I use the client in Flink , I get an error

```
Caused by: java.io.NotSerializableException: java.util.Optional
  at java.base/java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1185)
  at java.base/java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:349)
  at org.apache.flink.util.InstantiationUtil.serializeObject(InstantiationUtil.java:624)
  at org.apache.flink.api.java.ClosureCleaner.clean(ClosureCleaner.java:143)
  ... 48 more
```

### What is changed and how it works?

Optional in the getter method

### Check List for Tests

This PR has been tested by the at least one of the following methods:
- Unit test

### Side effects

- NO side effects

### Related changes

- NO related changes

https://stackoverflow.com/questions/24547673/why-java-util-optional-is-not-serializable-how-to-serialize-the-object-with-suc