### PR TITLE
[to #462] add version constraint for rawkv tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -582,6 +582,11 @@
                     <commitIdGenerationMode>full</commitIdGenerationMode>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M5</version>
+            </plugin>
         </plugins>
     </build>
 

--- a/src/test/java/org/tikv/BaseRawKVTest.java
+++ b/src/test/java/org/tikv/BaseRawKVTest.java
@@ -17,23 +17,21 @@
 
 package org.tikv;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.tikv.common.PDClient;
+import org.tikv.common.StoreVersion;
 import org.tikv.common.TiConfiguration;
+import org.tikv.common.TiSession;
 import org.tikv.util.TestUtils;
 
 public class BaseRawKVTest {
 
-  protected String getTiKVVersion() {
-    String tikvVersion = TestUtils.getEnv("TIKV_VERSION");
-    return tikvVersion == null ? "master" : tikvVersion;
-  }
-
   protected boolean tikvVersionNewerThan(String expectedVersion) {
-    String version = getTiKVVersion();
-    // the minimum version of master TiKV is v5.3.0
-    if (version.equals("master")) {
-      return true;
-    }
-    return version.compareTo(expectedVersion) >= 0;
+    TiConfiguration conf = createTiConfiguration();
+    TiSession session = TiSession.create(conf);
+    PDClient pdClient = session.getPDClient();
+    return StoreVersion.minTiKVVersion(expectedVersion, pdClient);
   }
 
   protected TiConfiguration createTiConfiguration() {

--- a/src/test/java/org/tikv/BaseRawKVTest.java
+++ b/src/test/java/org/tikv/BaseRawKVTest.java
@@ -17,8 +17,6 @@
 
 package org.tikv;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.tikv.common.PDClient;
 import org.tikv.common.StoreVersion;
 import org.tikv.common.TiConfiguration;

--- a/src/test/java/org/tikv/BaseRawKVTest.java
+++ b/src/test/java/org/tikv/BaseRawKVTest.java
@@ -21,6 +21,21 @@ import org.tikv.common.TiConfiguration;
 import org.tikv.util.TestUtils;
 
 public class BaseRawKVTest {
+
+  protected String getTiKVVersion() {
+    String tikvVersion = TestUtils.getEnv("TIKV_VERSION");
+    return tikvVersion == null ? "master" : tikvVersion;
+  }
+
+  protected boolean tikvVersionNewerThan(String expectedVersion) {
+    String version = getTiKVVersion();
+    // the minimum version of master TiKV is v5.3.0
+    if (version.equals("master")) {
+      return true;
+    }
+    return version.compareTo(expectedVersion) >= 0;
+  }
+
   protected TiConfiguration createTiConfiguration() {
     String pdAddrsStr = TestUtils.getEnv("RAWKV_PD_ADDRESSES");
 

--- a/src/test/java/org/tikv/common/PDClientIntegrationTest.java
+++ b/src/test/java/org/tikv/common/PDClientIntegrationTest.java
@@ -21,11 +21,13 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.tikv.BaseRawKVTest;
 
 public class PDClientIntegrationTest extends BaseRawKVTest {
+
   private TiSession session;
 
   @Before
@@ -44,6 +46,7 @@ public class PDClientIntegrationTest extends BaseRawKVTest {
 
   @Test
   public void testPauseCheck() throws Exception {
+    Assume.assumeTrue(tikvVersionNewerThan("v5.3.0"));
     try (PDClient client = session.getPDClient()) {
       PDChecker checker = PDChecker.Merge;
       for (int i = 0; i < 2; i++) {

--- a/src/test/java/org/tikv/common/importer/RawKVIngestTest.java
+++ b/src/test/java/org/tikv/common/importer/RawKVIngestTest.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.tikv.BaseRawKVTest;
@@ -37,6 +38,7 @@ import org.tikv.raw.RawKVClient;
 import org.tikv.util.TestUtils;
 
 public class RawKVIngestTest extends BaseRawKVTest {
+
   private TiSession session;
 
   private static final int KEY_NUMBER = 16;
@@ -59,6 +61,7 @@ public class RawKVIngestTest extends BaseRawKVTest {
 
   @Test
   public void rawKVIngestTest() {
+    Assume.assumeTrue(tikvVersionNewerThan("v5.2.0"));
     RawKVClient client = session.createRawClient();
 
     // gen test data

--- a/src/test/java/org/tikv/common/importer/RawKVIngestTest.java
+++ b/src/test/java/org/tikv/common/importer/RawKVIngestTest.java
@@ -91,6 +91,7 @@ public class RawKVIngestTest extends BaseRawKVTest {
 
   @Test
   public void rawKVIngestTestWithTTL() throws InterruptedException {
+    Assume.assumeTrue(tikvVersionNewerThan("v5.2.0"));
     long ttl = 10;
     RawKVClient client = session.createRawClient();
 

--- a/src/test/java/org/tikv/common/importer/RegionSplitTest.java
+++ b/src/test/java/org/tikv/common/importer/RegionSplitTest.java
@@ -24,6 +24,7 @@ import com.google.protobuf.ByteString;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.After;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.Test;
 import org.tikv.BaseRawKVTest;
@@ -32,6 +33,7 @@ import org.tikv.common.TiSession;
 import org.tikv.common.region.TiRegion;
 
 public class RegionSplitTest extends BaseRawKVTest {
+
   private TiSession session;
 
   private static final int KEY_NUMBER = 10;
@@ -53,6 +55,7 @@ public class RegionSplitTest extends BaseRawKVTest {
 
   @Test
   public void rawKVSplitTest() {
+    Assume.assumeTrue(tikvVersionNewerThan("v5.1.0"));
     List<byte[]> splitKeys = new ArrayList<>(KEY_NUMBER);
     for (int i = 0; i < KEY_NUMBER; i++) {
       splitKeys.add(genRandomKey(KEY_PREFIX, KEY_LENGTH));


### PR DESCRIPTION
Signed-off-by: iosmanthus <myosmanthustree@gmail.com>

<!-- Thank you for contributing to TiKV Java Client!

PR Title Format: "[close/to/fix #issue_number] summary" -->

### What problem does this PR solve?

Issue Number: close #462

Problem Description:
Some tests in the master branch are not compatible with older versions of TiKV, we need to add some version constraints to these tests and furthermore, add integration compatibility tests for the master branch.

### What is changed and how it works?

Use `Assume` to ignore some tests with version info reading from ENV.


### Check List for Tests

This PR has been tested by at least one of the following methods:
- Manual test (add detailed scripts or steps below)
