### PR TITLE
[close #497] let JVM ClassLoader load gRPC error related classes during warmup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -596,6 +596,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.0.0-M5</version>
+                <configuration>
+                    <forkMode>always</forkMode>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/org/tikv/common/TiSession.java
+++ b/src/main/java/org/tikv/common/TiSession.java
@@ -36,6 +36,7 @@ import org.tikv.common.key.Key;
 import org.tikv.common.meta.TiTimestamp;
 import org.tikv.common.region.*;
 import org.tikv.common.util.*;
+import org.tikv.kvproto.Errorpb;
 import org.tikv.kvproto.ImportSstpb;
 import org.tikv.kvproto.Metapb;
 import org.tikv.kvproto.Pdpb;
@@ -166,6 +167,13 @@ public class TiSession implements AutoCloseable {
     long warmUpStartTime = System.nanoTime();
     BackOffer backOffer = ConcreteBackOffer.newRawKVBackOff();
     try {
+      // let JVM ClassLoader load gRPC error related classes
+      // this operation may cost 100ms
+      Errorpb.Error.newBuilder()
+          .setNotLeader(Errorpb.NotLeader.newBuilder().build())
+          .build()
+          .toString();
+
       this.client = getPDClient();
       this.regionManager = getRegionManager();
       List<Metapb.Store> stores = this.client.getAllStores(backOffer);

--- a/src/test/java/org/tikv/raw/WarmupTest.java
+++ b/src/test/java/org/tikv/raw/WarmupTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 TiKV Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.tikv.raw;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.tikv.BaseRawKVTest;
+import org.tikv.common.TiConfiguration;
+import org.tikv.common.TiSession;
+import org.tikv.kvproto.Errorpb;
+
+public class WarmupTest extends BaseRawKVTest {
+
+  @Test
+  public void testErrorpbToStringEnableWarmup() throws Exception {
+    TiConfiguration conf = createTiConfiguration();
+    TiSession session = TiSession.create(conf);
+
+    long start = System.currentTimeMillis();
+    Errorpb.Error.newBuilder()
+        .setNotLeader(Errorpb.NotLeader.newBuilder().build())
+        .build()
+        .toString();
+    long end = System.currentTimeMillis();
+    assertTrue(end - start < 10);
+    session.close();
+  }
+
+  @Test
+  public void testErrorpbToStringDisableWarmup() throws Exception {
+    TiConfiguration conf = createTiConfiguration();
+    conf.setWarmUpEnable(false);
+    TiSession session = TiSession.create(conf);
+
+    long start = System.currentTimeMillis();
+    Errorpb.Error.newBuilder()
+        .setNotLeader(Errorpb.NotLeader.newBuilder().build())
+        .build()
+        .toString();
+    long end = System.currentTimeMillis();
+    assertTrue(end - start > 10);
+    session.close();
+  }
+}


### PR DESCRIPTION
Signed-off-by: marsishandsome <marsishandsome@gmail.com>

### What problem does this PR solve?

close https://github.com/tikv/client-java/issues/497

Problem Description:  Request timeout when receiving NOT_LEADER error the first time.

### What is changed and how it works?

The reason is that [error.toString](https://github.com/tikv/client-java/blob/v3.1.9/src/main/java/org/tikv/common/operation/RegionErrorHandler.java#L95) will trigger JVM ClassLoader load grpc error related classes, which costs more than 100ms.

Solution: let JVM JVM ClassLoader load grpc error related classes during warmup.
