### PR TITLE
[to #531] [WIP] tests: introduce Interceptor for mock server class

### DIFF
--- a/src/test/java/org/tikv/common/Interceptor.java
+++ b/src/test/java/org/tikv/common/Interceptor.java
@@ -1,0 +1,6 @@
+package org.tikv.common;
+
+public interface Interceptor<I, R> {
+
+  R apply(I request) throws Throwable;
+}

--- a/src/test/java/org/tikv/common/KVMockServer.java
+++ b/src/test/java/org/tikv/common/KVMockServer.java
@@ -162,9 +162,7 @@ public class KVMockServer extends TikvGrpc.TikvImplBase {
     }
   }
 
-  /**
-   *
-   */
+  /** */
   public void rawPut(
       org.tikv.kvproto.Kvrpcpb.RawPutRequest request,
       io.grpc.stub.StreamObserver<org.tikv.kvproto.Kvrpcpb.RawPutResponse> responseObserver) {
@@ -206,9 +204,7 @@ public class KVMockServer extends TikvGrpc.TikvImplBase {
     }
   }
 
-  /**
-   *
-   */
+  /** */
   public void rawDelete(
       org.tikv.kvproto.Kvrpcpb.RawDeleteRequest request,
       io.grpc.stub.StreamObserver<org.tikv.kvproto.Kvrpcpb.RawDeleteResponse> responseObserver) {

--- a/src/test/java/org/tikv/common/KVMockServer.java
+++ b/src/test/java/org/tikv/common/KVMockServer.java
@@ -162,7 +162,9 @@ public class KVMockServer extends TikvGrpc.TikvImplBase {
     }
   }
 
-  /** */
+  /**
+   *
+   */
   public void rawPut(
       org.tikv.kvproto.Kvrpcpb.RawPutRequest request,
       io.grpc.stub.StreamObserver<org.tikv.kvproto.Kvrpcpb.RawPutResponse> responseObserver) {
@@ -204,7 +206,9 @@ public class KVMockServer extends TikvGrpc.TikvImplBase {
     }
   }
 
-  /** */
+  /**
+   *
+   */
   public void rawDelete(
       org.tikv.kvproto.Kvrpcpb.RawDeleteRequest request,
       io.grpc.stub.StreamObserver<org.tikv.kvproto.Kvrpcpb.RawDeleteResponse> responseObserver) {

--- a/src/test/java/org/tikv/common/MockRequestInterceptor.java
+++ b/src/test/java/org/tikv/common/MockRequestInterceptor.java
@@ -1,0 +1,69 @@
+package org.tikv.common;
+
+import io.grpc.Status;
+import java.util.function.Function;
+
+public class MockRequestInterceptor<I, R> implements Interceptor<I, R> {
+
+  private Throwable error;
+  private long latency;
+  private Function<I, Throwable> checker;
+  private Function<I, R> handler;
+
+  public static class MockRequestInterceptorBuilder<I, R> {
+
+    private final MockRequestInterceptor<I, R> interceptor;
+
+    public MockRequestInterceptorBuilder() {
+      interceptor = new MockRequestInterceptor<>();
+    }
+
+    public MockRequestInterceptorBuilder<I, R> withError(Throwable error) {
+      interceptor.error = error;
+      return this;
+    }
+
+    public MockRequestInterceptorBuilder<I, R> withLatency(long latency) {
+      interceptor.latency = latency;
+      return this;
+    }
+
+    public MockRequestInterceptorBuilder<I, R> withChecker(Function<I, Throwable> checker) {
+      interceptor.checker = checker;
+      return this;
+    }
+
+    public MockRequestInterceptorBuilder<I, R> withHandler(Function<I, R> handler) {
+      interceptor.handler = handler;
+      return this;
+    }
+
+    public MockRequestInterceptor<I, R> build() {
+      return interceptor;
+    }
+  }
+
+  @Override
+  public R apply(I request) throws Throwable {
+    if (error != null) {
+      throw error;
+    }
+    if (checker != null) {
+      Throwable t = checker.apply(request);
+      if (t != null) {
+        throw t;
+      }
+    }
+    if (latency > 0) {
+      try {
+        Thread.sleep(latency);
+      } catch (InterruptedException ignored) {
+      }
+    }
+    R resp = handler.apply(request);
+    if (resp == null) {
+      throw new Throwable(Status.INTERNAL.asRuntimeException());
+    }
+    return resp;
+  }
+}

--- a/src/test/java/org/tikv/common/MockServerTest.java
+++ b/src/test/java/org/tikv/common/MockServerTest.java
@@ -63,10 +63,10 @@ public class MockServerTest extends PDMockServerTest {
             r.getPeers(0),
             r.getPeersList(),
             s.stream().map(TiStore::new).collect(Collectors.toList()));
-    leader.addGetRegionListener(
+    leader.addGetRegionInterceptor(
         request -> Pdpb.GetRegionResponse.newBuilder().setRegion(r).build());
     for (Metapb.Store store : s) {
-      leader.addGetStoreListener(
+      leader.addGetStoreInterceptor(
           (request) -> Pdpb.GetStoreResponse.newBuilder().setStore(store).build());
     }
     server = new KVMockServer();

--- a/src/test/java/org/tikv/common/MockThreeStoresTest.java
+++ b/src/test/java/org/tikv/common/MockThreeStoresTest.java
@@ -81,13 +81,13 @@ public class MockThreeStoresTest extends PDMockServerTest {
                 .build());
 
     for (PDMockServer server : pdServers) {
-      server.addGetRegionListener(
+      server.addGetRegionInterceptor(
           request ->
               Pdpb.GetRegionResponse.newBuilder()
                   .setLeader(peers.get(0))
                   .setRegion(region)
                   .build());
-      server.addGetStoreListener(
+      server.addGetStoreInterceptor(
           (request) -> {
             int i = (int) request.getStoreId() - 1;
             return Pdpb.GetStoreResponse.newBuilder().setStore(stores.get(i)).build();

--- a/src/test/java/org/tikv/common/PDClientMockTest.java
+++ b/src/test/java/org/tikv/common/PDClientMockTest.java
@@ -83,8 +83,8 @@ public class PDClientMockTest extends PDMockServerTest {
 
   @Test
   public void testGetRegionByKey() throws Exception {
-    byte[] startKey = new byte[]{1, 0, 2, 4};
-    byte[] endKey = new byte[]{1, 0, 2, 5};
+    byte[] startKey = new byte[] {1, 0, 2, 4};
+    byte[] endKey = new byte[] {1, 0, 2, 5};
     int confVer = 1026;
     int ver = 1027;
     leader.addGetRegionInterceptor(
@@ -114,8 +114,8 @@ public class PDClientMockTest extends PDMockServerTest {
 
   @Test
   public void testGetRegionById() throws Exception {
-    byte[] startKey = new byte[]{1, 0, 2, 4};
-    byte[] endKey = new byte[]{1, 0, 2, 5};
+    byte[] startKey = new byte[] {1, 0, 2, 4};
+    byte[] endKey = new byte[] {1, 0, 2, 5};
     int confVer = 1026;
     int ver = 1027;
 

--- a/src/test/java/org/tikv/common/PDClientMockTest.java
+++ b/src/test/java/org/tikv/common/PDClientMockTest.java
@@ -83,8 +83,8 @@ public class PDClientMockTest extends PDMockServerTest {
 
   @Test
   public void testGetRegionByKey() throws Exception {
-    byte[] startKey = new byte[] {1, 0, 2, 4};
-    byte[] endKey = new byte[] {1, 0, 2, 5};
+    byte[] startKey = new byte[]{1, 0, 2, 4};
+    byte[] endKey = new byte[]{1, 0, 2, 5};
     int confVer = 1026;
     int ver = 1027;
     leader.addGetRegionInterceptor(
@@ -114,8 +114,8 @@ public class PDClientMockTest extends PDMockServerTest {
 
   @Test
   public void testGetRegionById() throws Exception {
-    byte[] startKey = new byte[] {1, 0, 2, 4};
-    byte[] endKey = new byte[] {1, 0, 2, 5};
+    byte[] startKey = new byte[]{1, 0, 2, 4};
+    byte[] endKey = new byte[]{1, 0, 2, 5};
     int confVer = 1026;
     int ver = 1027;
 

--- a/src/test/java/org/tikv/common/PDClientMockTest.java
+++ b/src/test/java/org/tikv/common/PDClientMockTest.java
@@ -83,8 +83,8 @@ public class PDClientMockTest extends PDMockServerTest {
 
   @Test
   public void testGetRegionByKey() throws Exception {
-    byte[] startKey = new byte[]{1, 0, 2, 4};
-    byte[] endKey = new byte[]{1, 0, 2, 5};
+    byte[] startKey = new byte[] {1, 0, 2, 4};
+    byte[] endKey = new byte[] {1, 0, 2, 5};
     int confVer = 1026;
     int ver = 1027;
     leader.addGetRegionInterceptor(
@@ -114,8 +114,8 @@ public class PDClientMockTest extends PDMockServerTest {
 
   @Test
   public void testGetRegionById() throws Exception {
-    byte[] startKey = new byte[]{1, 0, 2, 4};
-    byte[] endKey = new byte[]{1, 0, 2, 5};
+    byte[] startKey = new byte[] {1, 0, 2, 4};
+    byte[] endKey = new byte[] {1, 0, 2, 5};
     int confVer = 1026;
     int ver = 1027;
 
@@ -167,10 +167,11 @@ public class PDClientMockTest extends PDMockServerTest {
       assertEquals("v1", r.getLabels(0).getValue());
       assertEquals("v2", r.getLabels(1).getValue());
 
-      leader.addGetStoreInterceptor(request ->
-          GrpcUtils.makeGetStoreResponse(
-              leader.getClusterId(),
-              GrpcUtils.makeStore(storeId, testAddress, Metapb.StoreState.Tombstone)));
+      leader.addGetStoreInterceptor(
+          request ->
+              GrpcUtils.makeGetStoreResponse(
+                  leader.getClusterId(),
+                  GrpcUtils.makeStore(storeId, testAddress, Metapb.StoreState.Tombstone)));
       assertEquals(StoreState.Tombstone, client.getStore(defaultBackOff(), storeId).getState());
     }
   }
@@ -186,15 +187,16 @@ public class PDClientMockTest extends PDMockServerTest {
     AtomicInteger i = new AtomicInteger();
     Interceptor<GetStoreRequest, GetStoreResponse> interceptor =
         new MockRequestInterceptorBuilder<GetStoreRequest, GetStoreResponse>()
-            .withHandler(request -> {
+            .withHandler(
+                request -> {
                   if (i.getAndIncrement() < 2) {
                     return null;
                   } else {
                     return GrpcUtils.makeGetStoreResponse(
                         leader.getClusterId(), GrpcUtils.makeStore(storeId, "", StoreState.Up));
                   }
-                }
-            ).build();
+                })
+            .build();
     leader.addGetStoreInterceptor(interceptor);
 
     try (PDClient client = session.getPDClient()) {
@@ -210,16 +212,19 @@ public class PDClientMockTest extends PDMockServerTest {
 
       // Should fail
       AtomicInteger j = new AtomicInteger();
-      interceptor = new MockRequestInterceptorBuilder<GetStoreRequest, GetStoreResponse>().withHandler(
-          request -> {
-            if (j.getAndIncrement() < 6) {
-              return null;
-            } else {
-              return GrpcUtils.makeGetStoreResponse(
-                  leader.getClusterId(), GrpcUtils.makeStore(storeId, "", Metapb.StoreState.Up));
-            }
-          }
-      ).build();
+      interceptor =
+          new MockRequestInterceptorBuilder<GetStoreRequest, GetStoreResponse>()
+              .withHandler(
+                  request -> {
+                    if (j.getAndIncrement() < 6) {
+                      return null;
+                    } else {
+                      return GrpcUtils.makeGetStoreResponse(
+                          leader.getClusterId(),
+                          GrpcUtils.makeStore(storeId, "", Metapb.StoreState.Up));
+                    }
+                  })
+              .build();
       leader.addGetStoreInterceptor(interceptor);
 
       try {

--- a/src/test/java/org/tikv/common/PDMockServer.java
+++ b/src/test/java/org/tikv/common/PDMockServer.java
@@ -66,12 +66,10 @@ public class PDMockServer extends PDGrpc.PDImplBase {
       private int logical = 0;
 
       @Override
-      public void onNext(TsoRequest value) {
-      }
+      public void onNext(TsoRequest value) {}
 
       @Override
-      public void onError(Throwable t) {
-      }
+      public void onError(Throwable t) {}
 
       @Override
       public void onCompleted() {

--- a/src/test/java/org/tikv/common/PDMockServerTest.java
+++ b/src/test/java/org/tikv/common/PDMockServerTest.java
@@ -53,8 +53,7 @@ public abstract class PDMockServerTest {
                   server.getClusterId(),
                   GrpcUtils.makeMember(1, "http://" + addr + ":" + basePort),
                   GrpcUtils.makeMember(2, "http://" + addr + ":" + (basePort + 1)),
-                  GrpcUtils.makeMember(3, "http://" + addr + ":" + (basePort + 2)))
-      );
+                  GrpcUtils.makeMember(3, "http://" + addr + ":" + (basePort + 2))));
 
       pdServers.add(server);
     }

--- a/src/test/java/org/tikv/common/PDMockServerTest.java
+++ b/src/test/java/org/tikv/common/PDMockServerTest.java
@@ -58,8 +58,8 @@ public abstract class PDMockServerTest {
                           server.getClusterId(),
                           GrpcUtils.makeMember(1, "http://" + addr + ":" + basePort),
                           GrpcUtils.makeMember(2, "http://" + addr + ":" + (basePort + 1)),
-                          GrpcUtils.makeMember(3, "http://" + addr + ":" + (basePort + 2)))
-              ).build();
+                          GrpcUtils.makeMember(3, "http://" + addr + ":" + (basePort + 2))))
+              .build();
       server.addGetMembersInterceptor(interceptor);
 
       pdServers.add(server);

--- a/src/test/java/org/tikv/common/PDMockServerTest.java
+++ b/src/test/java/org/tikv/common/PDMockServerTest.java
@@ -23,9 +23,6 @@ import java.util.ArrayList;
 import java.util.List;
 import org.junit.After;
 import org.junit.Before;
-import org.tikv.common.MockRequestInterceptor.MockRequestInterceptorBuilder;
-import org.tikv.kvproto.Pdpb.GetMembersRequest;
-import org.tikv.kvproto.Pdpb.GetMembersResponse;
 
 public abstract class PDMockServerTest {
 
@@ -50,17 +47,14 @@ public abstract class PDMockServerTest {
       PDMockServer server = new PDMockServer();
       server.start(CLUSTER_ID, basePort + i);
 
-      Interceptor<GetMembersRequest, GetMembersResponse> interceptor =
-          new MockRequestInterceptorBuilder<GetMembersRequest, GetMembersResponse>()
-              .withHandler(
-                  (request) ->
-                      GrpcUtils.makeGetMembersResponse(
-                          server.getClusterId(),
-                          GrpcUtils.makeMember(1, "http://" + addr + ":" + basePort),
-                          GrpcUtils.makeMember(2, "http://" + addr + ":" + (basePort + 1)),
-                          GrpcUtils.makeMember(3, "http://" + addr + ":" + (basePort + 2))))
-              .build();
-      server.addGetMembersInterceptor(interceptor);
+      server.addGetMembersInterceptor(
+          (request) ->
+              GrpcUtils.makeGetMembersResponse(
+                  server.getClusterId(),
+                  GrpcUtils.makeMember(1, "http://" + addr + ":" + basePort),
+                  GrpcUtils.makeMember(2, "http://" + addr + ":" + (basePort + 1)),
+                  GrpcUtils.makeMember(3, "http://" + addr + ":" + (basePort + 2)))
+      );
 
       pdServers.add(server);
     }

--- a/src/test/java/org/tikv/common/RegionManagerTest.java
+++ b/src/test/java/org/tikv/common/RegionManagerTest.java
@@ -66,7 +66,7 @@ public class RegionManagerTest extends PDMockServerTest {
     int ver = 1027;
     long regionId = 233;
     String testAddress = "127.0.0.1";
-    leader.addGetRegionListener(
+    leader.addGetRegionInterceptor(
         request ->
             GrpcUtils.makeGetRegionResponse(
                 leader.getClusterId(),
@@ -80,7 +80,7 @@ public class RegionManagerTest extends PDMockServerTest {
 
     AtomicInteger i = new AtomicInteger(0);
     long[] ids = new long[] {10, 20};
-    leader.addGetStoreListener(
+    leader.addGetStoreInterceptor(
         (request ->
             GrpcUtils.makeGetStoreResponse(
                 leader.getClusterId(),
@@ -108,7 +108,7 @@ public class RegionManagerTest extends PDMockServerTest {
     int confVer = 1026;
     int ver = 1027;
     long regionId = 233;
-    leader.addGetRegionListener(
+    leader.addGetRegionInterceptor(
         request ->
             GrpcUtils.makeGetRegionResponse(
                 leader.getClusterId(),
@@ -122,7 +122,7 @@ public class RegionManagerTest extends PDMockServerTest {
 
     AtomicInteger i = new AtomicInteger(0);
     long[] ids = new long[] {10, 20};
-    leader.addGetStoreListener(
+    leader.addGetStoreInterceptor(
         (request ->
             GrpcUtils.makeGetStoreResponse(
                 leader.getClusterId(),
@@ -142,7 +142,7 @@ public class RegionManagerTest extends PDMockServerTest {
   public void getStoreById() {
     long storeId = 234;
     String testAddress = "testAddress";
-    leader.addGetStoreListener(
+    leader.addGetStoreInterceptor(
         request ->
             GrpcUtils.makeGetStoreResponse(
                 leader.getClusterId(),
@@ -155,7 +155,7 @@ public class RegionManagerTest extends PDMockServerTest {
     TiStore store = mgr.getStoreById(storeId);
     assertEquals(store.getStore().getId(), storeId);
 
-    leader.addGetStoreListener(
+    leader.addGetStoreInterceptor(
         request ->
             GrpcUtils.makeGetStoreResponse(
                 leader.getClusterId(),


### PR DESCRIPTION
Signed-off-by: iosmanthus <myosmanthustree@gmail.com>
### What problem does this PR solve?

Issue Number: to #531

Problem Description:

This pull request introduce a universal Interceptor for mock server class, including:

- [x]  `PDMockServer`
- [ ] `KVMockServer`

It supports:
1. request checker.
2. inject lantency.
3. inject (error) response.
4.. customize request handler.


You could write a Interceptor like:

```java
 new MockRequestInterceptorBuilder<GetStoreRequest, GetStoreResponse>()
			.withChecker(request -> { // check request; })
			.withLatency(100) // 100 ms latency
            .withHandler(request -> { // return something ;})
			.build();
```


### What is changed and how it works?


### Check List for Tests

This PR has been tested by the at least one of the following methods:
- Unit test
- Integration test

