### PR TITLE
[close #540] rawkv: fix scan return empty set while exist empty key

### DIFF
--- a/src/main/java/org/tikv/common/operation/iterator/RawScanIterator.java
+++ b/src/main/java/org/tikv/common/operation/iterator/RawScanIterator.java
@@ -30,6 +30,7 @@ import org.tikv.common.util.BackOffer;
 import org.tikv.kvproto.Kvrpcpb;
 
 public class RawScanIterator extends ScanIterator {
+
   private final BackOffer scanBackOffer;
 
   public RawScanIterator(
@@ -67,11 +68,18 @@ public class RawScanIterator extends ScanIterator {
     }
   }
 
-  private boolean notEndOfScan() {
-    return limit > 0
-        && !(processingLastBatch
-            && (index >= currentCache.size()
-                || Key.toRawKey(currentCache.get(index).getKey()).compareTo(endKey) >= 0));
+  private boolean eof() {
+    if (limit <= 0) {
+      return true;
+    }
+    if (!processingLastBatch) {
+      return false;
+    }
+    if (index >= currentCache.size()) {
+      return true;
+    }
+    ByteString lastKey = currentCache.get(index).getKey();
+    return !lastKey.isEmpty() && Key.toRawKey(lastKey).compareTo(endKey) >= 0;
   }
 
   boolean isCacheDrained() {
@@ -90,7 +98,7 @@ public class RawScanIterator extends ScanIterator {
         return false;
       }
     }
-    return notEndOfScan();
+    return !eof();
   }
 
   private Kvrpcpb.KvPair getCurrent() {

--- a/src/main/java/org/tikv/common/operation/iterator/RawScanIterator.java
+++ b/src/main/java/org/tikv/common/operation/iterator/RawScanIterator.java
@@ -68,7 +68,7 @@ public class RawScanIterator extends ScanIterator {
     }
   }
 
-  private boolean eof() {
+  private boolean endOfScan() {
     if (limit <= 0) {
       return true;
     }
@@ -98,7 +98,7 @@ public class RawScanIterator extends ScanIterator {
         return false;
       }
     }
-    return !eof();
+    return !endOfScan();
   }
 
   private Kvrpcpb.KvPair getCurrent() {

--- a/src/main/java/org/tikv/common/operation/iterator/RawScanIterator.java
+++ b/src/main/java/org/tikv/common/operation/iterator/RawScanIterator.java
@@ -69,14 +69,8 @@ public class RawScanIterator extends ScanIterator {
   }
 
   private boolean endOfScan() {
-    if (limit <= 0) {
-      return true;
-    }
     if (!processingLastBatch) {
       return false;
-    }
-    if (index >= currentCache.size()) {
-      return true;
     }
     ByteString lastKey = currentCache.get(index).getKey();
     return !lastKey.isEmpty() && Key.toRawKey(lastKey).compareTo(endKey) >= 0;

--- a/src/main/java/org/tikv/common/operation/iterator/ScanIterator.java
+++ b/src/main/java/org/tikv/common/operation/iterator/ScanIterator.java
@@ -90,7 +90,7 @@ public abstract class ScanIterator implements Iterator<Kvrpcpb.KvPair> {
       Key lastKey = Key.EMPTY;
       // Session should be single-threaded itself
       // so that we don't worry about conf change in the middle
-      // of a transaction. Otherwise below code might lose data
+      // of a transaction. Otherwise, below code might lose data
       if (currentCache.size() < limit) {
         startKey = curRegionEndKey;
         lastKey = Key.toRawKey(curRegionEndKey);

--- a/src/test/java/org/tikv/raw/RawKVClientTest.java
+++ b/src/test/java/org/tikv/raw/RawKVClientTest.java
@@ -381,7 +381,9 @@ public class RawKVClientTest extends BaseRawKVTest {
   // https://github.com/tikv/client-java/issues/540
   @Test
   public void scanTestForIssue540() {
+    client.deleteRange(ByteString.EMPTY, ByteString.EMPTY);
     client.put(ByteString.EMPTY, ByteString.EMPTY);
+    logger.info(client.scan(ByteString.EMPTY, 2).toString());
     Assert.assertEquals(1, client.scan(ByteString.EMPTY, 2).size());
     client.delete(ByteString.EMPTY);
   }

--- a/src/test/java/org/tikv/raw/RawKVClientTest.java
+++ b/src/test/java/org/tikv/raw/RawKVClientTest.java
@@ -392,9 +392,7 @@ public class RawKVClientTest extends BaseRawKVTest {
     baseTest(100, 100, 100, 100, false, true, true, true, true);
   }
 
-  /**
-   * Example of benchmarking base test
-   */
+  /** Example of benchmarking base test */
   public void benchmark() {
     baseTest(TEST_CASES, TEST_CASES, 200, 5000, true, false, false, false, false);
     baseTest(TEST_CASES, TEST_CASES, 200, 5000, true, true, true, true, true);


### PR DESCRIPTION
Signed-off-by: iosmanthus <myosmanthustree@gmail.com>

<!-- Thank you for contributing to TiKV Java Client!

PR Title Format: "[close/to/fix #issue_number] summary" -->

### What problem does this PR solve?

Issue Number: close #540

Problem Description:

This pull request adds an empty key check for `RawScanIterator.hasNext`, otherwise, if there is an empty key in TiKV, the scan will always return an empty set.


### Check List for Tests

This PR has been tested by at least one of the following methods:
- Integration test

