### PR TITLE
[close #540] rawkv: fix scan return empty set while exist empty key (#541)

### DIFF
--- a/src/main/java/org/tikv/common/operation/iterator/RawScanIterator.java
+++ b/src/main/java/org/tikv/common/operation/iterator/RawScanIterator.java
@@ -28,6 +28,7 @@ import org.tikv.common.util.BackOffer;
 import org.tikv.kvproto.Kvrpcpb;
 
 public class RawScanIterator extends ScanIterator {
+
   private final BackOffer scanBackOffer;
 
   public RawScanIterator(
@@ -65,11 +66,12 @@ public class RawScanIterator extends ScanIterator {
     }
   }
 
-  private boolean notEndOfScan() {
-    return limit > 0
-        && !(processingLastBatch
-            && (index >= currentCache.size()
-                || Key.toRawKey(currentCache.get(index).getKey()).compareTo(endKey) >= 0));
+  private boolean endOfScan() {
+    if (!processingLastBatch) {
+      return false;
+    }
+    ByteString lastKey = currentCache.get(index).getKey();
+    return !lastKey.isEmpty() && Key.toRawKey(lastKey).compareTo(endKey) >= 0;
   }
 
   boolean isCacheDrained() {
@@ -88,7 +90,7 @@ public class RawScanIterator extends ScanIterator {
         return false;
       }
     }
-    return notEndOfScan();
+    return !endOfScan();
   }
 
   private Kvrpcpb.KvPair getCurrent() {

--- a/src/main/java/org/tikv/common/operation/iterator/ScanIterator.java
+++ b/src/main/java/org/tikv/common/operation/iterator/ScanIterator.java
@@ -88,7 +88,7 @@ public abstract class ScanIterator implements Iterator<Kvrpcpb.KvPair> {
       Key lastKey = Key.EMPTY;
       // Session should be single-threaded itself
       // so that we don't worry about conf change in the middle
-      // of a transaction. Otherwise below code might lose data
+      // of a transaction. Otherwise, below code might lose data
       if (currentCache.size() < limit) {
         startKey = curRegionEndKey;
         lastKey = Key.toRawKey(curRegionEndKey);

--- a/src/test/java/org/tikv/raw/RawKVClientTest.java
+++ b/src/test/java/org/tikv/raw/RawKVClientTest.java
@@ -1,14 +1,32 @@
 package org.tikv.raw;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
 import java.io.IOException;
-import java.util.*;
-import java.util.concurrent.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Random;
+import java.util.TreeMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -361,12 +379,41 @@ public class RawKVClientTest extends BaseRawKVTest {
   }
 
   @Test
+  public void scanTestForIssue540() {
+    ByteString splitKeyA = ByteString.copyFromUtf8("splitKeyA");
+    ByteString splitKeyB = ByteString.copyFromUtf8("splitKeyB");
+    session.splitRegionAndScatter(ImmutableList.of(splitKeyA.toByteArray(), splitKeyB.toByteArray()));
+    client.deleteRange(ByteString.EMPTY, ByteString.EMPTY);
+
+    client.put(ByteString.EMPTY, ByteString.EMPTY);
+    client.put(splitKeyA, ByteString.EMPTY);
+    Assert.assertEquals(0, client.scan(ByteString.EMPTY, 0).size());
+    Assert.assertEquals(1, client.scan(ByteString.EMPTY, 1).size());
+    Assert.assertEquals(2, client.scan(ByteString.EMPTY, 2).size());
+    Assert.assertEquals(2, client.scan(ByteString.EMPTY, 3).size());
+
+    client.deleteRange(ByteString.EMPTY, ByteString.EMPTY);
+
+    client.put(ByteString.EMPTY, ByteString.EMPTY);
+    client.put(splitKeyA, ByteString.EMPTY);
+    client.put(splitKeyA.concat(ByteString.copyFromUtf8("1")), ByteString.EMPTY);
+    client.put(splitKeyA.concat(ByteString.copyFromUtf8("2")), ByteString.EMPTY);
+    client.put(splitKeyA.concat(ByteString.copyFromUtf8("3")), ByteString.EMPTY);
+    client.put(splitKeyB.concat(ByteString.copyFromUtf8("1")), ByteString.EMPTY);
+    Assert.assertEquals(6, client.scan(ByteString.EMPTY, 7).size());
+    Assert.assertEquals(0, client.scan(ByteString.EMPTY, -1).size());
+    client.deleteRange(ByteString.EMPTY, ByteString.EMPTY);
+  }
+
+  @Test
   public void validate() {
     baseTest(100, 100, 100, 100, false, false, false, false, false);
     baseTest(100, 100, 100, 100, false, true, true, true, true);
   }
 
-  /** Example of benchmarking base test */
+  /**
+   * Example of benchmarking base test
+   */
   public void benchmark() {
     baseTest(TEST_CASES, TEST_CASES, 200, 5000, true, false, false, false, false);
     baseTest(TEST_CASES, TEST_CASES, 200, 5000, true, true, true, true, true);
@@ -449,7 +496,9 @@ public class RawKVClientTest extends BaseRawKVTest {
       int i = cnt;
       completionService.submit(
           () -> {
-            for (int j = 0; j < base; j++) checkDelete(remainingKeys.get(i * base + j).getKey());
+            for (int j = 0; j < base; j++) {
+              checkDelete(remainingKeys.get(i * base + j).getKey());
+            }
             return null;
           });
     }
@@ -942,6 +991,7 @@ public class RawKVClientTest extends BaseRawKVTest {
   }
 
   private static class ByteStringComparator implements Comparator<ByteString> {
+
     @Override
     public int compare(ByteString startKey, ByteString endKey) {
       return FastByteComparisons.compareTo(startKey.toByteArray(), endKey.toByteArray());

--- a/src/test/java/org/tikv/raw/RawKVClientTest.java
+++ b/src/test/java/org/tikv/raw/RawKVClientTest.java
@@ -46,6 +46,7 @@ import org.tikv.common.util.ScanOption;
 import org.tikv.kvproto.Kvrpcpb;
 
 public class RawKVClientTest extends BaseRawKVTest {
+
   private static final String RAW_PREFIX = "raw_\u0001_";
   private static final int KEY_POOL_SIZE = 1000000;
   private static final int TEST_CASES = 10000;
@@ -382,7 +383,14 @@ public class RawKVClientTest extends BaseRawKVTest {
   public void scanTestForIssue540() {
     ByteString splitKeyA = ByteString.copyFromUtf8("splitKeyA");
     ByteString splitKeyB = ByteString.copyFromUtf8("splitKeyB");
-    session.splitRegionAndScatter(ImmutableList.of(splitKeyA.toByteArray(), splitKeyB.toByteArray()));
+    int splitRegionBackoffMS = 12000;
+    int scatterRegionBackoffMS = 30000;
+    int scatterWaitMS = 300000;
+    session.splitRegionAndScatter(
+        ImmutableList.of(splitKeyA.toByteArray(), splitKeyB.toByteArray()),
+        splitRegionBackoffMS,
+        scatterRegionBackoffMS,
+        scatterWaitMS);
     client.deleteRange(ByteString.EMPTY, ByteString.EMPTY);
 
     client.put(ByteString.EMPTY, ByteString.EMPTY);
@@ -411,9 +419,7 @@ public class RawKVClientTest extends BaseRawKVTest {
     baseTest(100, 100, 100, 100, false, true, true, true, true);
   }
 
-  /**
-   * Example of benchmarking base test
-   */
+  /** Example of benchmarking base test */
   public void benchmark() {
     baseTest(TEST_CASES, TEST_CASES, 200, 5000, true, false, false, false, false);
     baseTest(TEST_CASES, TEST_CASES, 200, 5000, true, true, true, true, true);


### PR DESCRIPTION
cherry-pick #541 to release-3.1
You can switch your code base to this Pull Request by using [git-extras](https://github.com/tj/git-extras):
```bash
# In client-java repo:
git pr https://github.com/tikv/client-java/pull/548
```

---

Signed-off-by: iosmanthus <myosmanthustree@gmail.com>

<!-- Thank you for contributing to TiKV Java Client!

PR Title Format: "[close/to/fix #issue_number] summary" -->

### What problem does this PR solve?

Issue Number: close #540

Problem Description:

This pull request adds an empty key check for `RawScanIterator.hasNext`, otherwise, if there is an empty key in TiKV, the scan will always return an empty set.


### Check List for Tests

This PR has been tested by at least one of the following methods:
- Integration test

