### PR TITLE
[to #556] slowlog: attach cluster_id and pd_addresses to slow log properties

### DIFF
--- a/src/main/java/org/tikv/common/PDClient.java
+++ b/src/main/java/org/tikv/common/PDClient.java
@@ -749,6 +749,7 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDFutureStub>
   }
 
   static class PDClientWrapper {
+
     private final String leaderInfo;
     private final PDBlockingStub blockingStub;
     private final PDFutureStub asyncStub;
@@ -839,5 +840,13 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDFutureStub>
     }
 
     return builder.build();
+  }
+
+  public long getClusterId() {
+    return header.getClusterId();
+  }
+
+  public List<URI> getPdAddrs() {
+    return pdAddrs;
   }
 }

--- a/src/main/java/org/tikv/common/PDClient.java
+++ b/src/main/java/org/tikv/common/PDClient.java
@@ -749,7 +749,6 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDFutureStub>
   }
 
   static class PDClientWrapper {
-
     private final String leaderInfo;
     private final PDBlockingStub blockingStub;
     private final PDFutureStub asyncStub;

--- a/src/main/java/org/tikv/common/log/SlowLog.java
+++ b/src/main/java/org/tikv/common/log/SlowLog.java
@@ -17,7 +17,11 @@
 
 package org.tikv.common.log;
 
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+
 public interface SlowLog {
+
   SlowLogSpan start(String name);
 
   long getTraceId();
@@ -25,6 +29,12 @@ public interface SlowLog {
   long getThresholdMS();
 
   void setError(Throwable err);
+
+  SlowLog withFields(Map<String, Object> fields);
+
+  default SlowLog withField(String key, Object value) {
+    return withFields(ImmutableMap.of(key, value));
+  }
 
   void log();
 }

--- a/src/main/java/org/tikv/common/log/SlowLogEmptyImpl.java
+++ b/src/main/java/org/tikv/common/log/SlowLogEmptyImpl.java
@@ -17,6 +17,8 @@
 
 package org.tikv.common.log;
 
+import java.util.Map;
+
 public class SlowLogEmptyImpl implements SlowLog {
   public static final SlowLogEmptyImpl INSTANCE = new SlowLogEmptyImpl();
 
@@ -39,6 +41,11 @@ public class SlowLogEmptyImpl implements SlowLog {
 
   @Override
   public void setError(Throwable err) {}
+
+  @Override
+  public SlowLog withFields(Map<String, Object> fields) {
+    return this;
+  }
 
   @Override
   public void log() {}

--- a/src/main/java/org/tikv/common/log/SlowLogImpl.java
+++ b/src/main/java/org/tikv/common/log/SlowLogImpl.java
@@ -22,12 +22,16 @@ import com.google.gson.JsonObject;
 import java.math.BigInteger;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Random;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class SlowLogImpl implements SlowLog {
+
   private static final Logger logger = LoggerFactory.getLogger(SlowLogImpl.class);
 
   private static final int MAX_SPAN_SIZE = 1024;
@@ -35,6 +39,7 @@ public class SlowLogImpl implements SlowLog {
   private static final Random random = new Random();
 
   private final List<SlowLogSpan> slowLogSpans = new ArrayList<>();
+  private final HashMap<String, Object> fields = new HashMap<>();
   private Throwable error = null;
 
   private final long startMS;
@@ -82,6 +87,12 @@ public class SlowLogImpl implements SlowLog {
   }
 
   @Override
+  public SlowLog withFields(Map<String, Object> fields) {
+    this.fields.putAll(fields);
+    return this;
+  }
+
+  @Override
   public void log() {
     recordTime();
     if (error != null || timeExceeded()) {
@@ -119,6 +130,25 @@ public class SlowLogImpl implements SlowLog {
       jsonArray.add(slowLogSpan.toJsonElement());
     }
     jsonObject.add("spans", jsonArray);
+
+    for (Entry<String, Object> entry : fields.entrySet()) {
+      Object value = entry.getValue();
+      if (value instanceof List) {
+        JsonArray field = new JsonArray();
+        for (Object o : (List<?>) value) {
+          field.add(o.toString());
+        }
+        jsonObject.add(entry.getKey(), field);
+      } else if (value instanceof Map) {
+        JsonObject field = new JsonObject();
+        for (Entry<?, ?> e : ((Map<?, ?>) value).entrySet()) {
+          field.addProperty(e.getKey().toString(), e.getValue().toString());
+        }
+        jsonObject.add(entry.getKey(), field);
+      } else {
+        jsonObject.addProperty(entry.getKey(), value.toString());
+      }
+    }
 
     return jsonObject;
   }

--- a/src/main/java/org/tikv/raw/RawKVClient.java
+++ b/src/main/java/org/tikv/raw/RawKVClient.java
@@ -127,9 +127,7 @@ public class RawKVClient implements RawKVClientBase {
   }
 
   private SlowLog withClusterInfo(SlowLog logger) {
-    return logger
-        .withField("cluster_id", clusterId)
-        .withField("pd_addresses", pdAddresses);
+    return logger.withField("cluster_id", clusterId).withField("pd_addresses", pdAddresses);
   }
 
   @Override
@@ -387,17 +385,17 @@ public class RawKVClient implements RawKVClientBase {
   public List<List<ByteString>> batchScanKeys(
       List<Pair<ByteString, ByteString>> ranges, int eachLimit) {
     return batchScan(
-        ranges
-            .stream()
-            .map(
-                range ->
-                    ScanOption.newBuilder()
-                        .setStartKey(range.first)
-                        .setEndKey(range.second)
-                        .setLimit(eachLimit)
-                        .setKeyOnly(true)
-                        .build())
-            .collect(Collectors.toList()))
+            ranges
+                .stream()
+                .map(
+                    range ->
+                        ScanOption.newBuilder()
+                            .setStartKey(range.first)
+                            .setEndKey(range.second)
+                            .setLimit(eachLimit)
+                            .setKeyOnly(true)
+                            .build())
+                .collect(Collectors.toList()))
         .stream()
         .map(kvs -> kvs.stream().map(kv -> kv.getKey()).collect(Collectors.toList()))
         .collect(Collectors.toList());
@@ -640,7 +638,7 @@ public class RawKVClient implements RawKVClientBase {
    * Ingest KV pairs to RawKV using StreamKV API.
    *
    * @param list
-   * @param ttl  the ttl of the key (in seconds), 0 means the key will never be outdated
+   * @param ttl the ttl of the key (in seconds), 0 means the key will never be outdated
    */
   public synchronized void ingest(List<Pair<ByteString, ByteString>> list, Long ttl)
       throws GrpcException {
@@ -1069,7 +1067,7 @@ public class RawKVClient implements RawKVClientBase {
    * Scan all raw key-value pairs from TiKV in range [startKey, endKey)
    *
    * @param startKey raw start key, inclusive
-   * @param endKey   raw end key, exclusive
+   * @param endKey raw end key, exclusive
    * @return iterator of key-value pairs in range
    */
   public Iterator<KvPair> scan0(ByteString startKey, ByteString endKey) {
@@ -1088,8 +1086,8 @@ public class RawKVClient implements RawKVClientBase {
    * Scan keys with prefix
    *
    * @param prefixKey prefix key
-   * @param limit     limit of keys retrieved
-   * @param keyOnly   whether to scan in keyOnly mode
+   * @param limit limit of keys retrieved
+   * @param keyOnly whether to scan in keyOnly mode
    * @return kvPairs iterator with the specified prefix
    */
   public Iterator<KvPair> scanPrefix0(ByteString prefixKey, int limit, boolean keyOnly) {
@@ -1108,8 +1106,8 @@ public class RawKVClient implements RawKVClientBase {
    * Scan all raw key-value pairs from TiKV in range [startKey, endKey)
    *
    * @param startKey raw start key, inclusive
-   * @param endKey   raw end key, exclusive
-   * @param keyOnly  whether to scan in key-only mode
+   * @param endKey raw end key, exclusive
+   * @param keyOnly whether to scan in key-only mode
    * @return iterator of key-value pairs in range
    */
   public Iterator<KvPair> scan0(ByteString startKey, ByteString endKey, boolean keyOnly) {


### PR DESCRIPTION
Signed-off-by: iosmanthus <myosmanthustree@gmail.com>

<!-- Thank you for contributing to TiKV Java Client!

PR Title Format: "[close/to/fix #issue_number] summary" -->

### What problem does this PR solve?

Issue Number: to #556

Problem Description:
Attach `cluster_id` and `pd_addresses` to slow log to distinguish the request destination while handling multiple TiKV clusters. 

### What is changed and how does it work?
Add `withFields` for `SlowLogImpl`, and use this interface to attach info dynamically while constructing the slow logger.


### Code changes

<!-- REMOVE the items that are not applicable -->
- Has exported function/method change


### Check List for Tests

This PR has been tested by at least one of the following methods:
- Unit test


### Related changes

<!-- REMOVE the items that are not applicable -->
- Need to cherry-pick to the release branch
- Need to update the documentation
- Need to be included in the release note
