### PR TITLE
[close #567] upgrade jackson-databind to 2.13.2.2 to fix CVE-2020-36518

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,8 @@
         <netty.tcnative.version>2.0.34.Final</netty.tcnative.version>
         <gson.version>2.8.9</gson.version>
         <powermock.version>1.6.6</powermock.version>
-        <jackson.version>2.12.3</jackson.version>
+        <jackson-annotations.version>2.13.2</jackson-annotations.version>
+        <jackson.version>2.13.2.2</jackson.version>
         <trove4j.version>3.0.1</trove4j.version>
         <jetcd.version>0.4.1</jetcd.version>
         <joda-time.version>2.9.9</joda-time.version>
@@ -177,7 +178,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson-annotations.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Signed-off-by: iosmanthus <myosmanthustree@gmail.com>

<!-- Thank you for contributing to TiKV Java Client!

PR Title Format: "[close/to/fix #issue_number] summary" -->

### What problem does this PR solve?

Issue Number: close #567

Problem Description:

upgrade `jackson-databind` to 2.13.2.2 to fix CVE-2020-36518

### What is changed and how does it work?
### Related changes

<!-- REMOVE the items that are not applicable -->
- Need to cherry-pick the release branch
- Need to update the documentation
- Need to be included in the release note
- NO related changes
