### PR TITLE
[close #606]: change the default prefix for API v2

### DIFF
--- a/src/main/java/org/tikv/common/apiversion/RequestKeyV2Codec.java
+++ b/src/main/java/org/tikv/common/apiversion/RequestKeyV2Codec.java
@@ -23,13 +23,15 @@ import org.tikv.kvproto.Metapb;
 import org.tikv.kvproto.Metapb.Region;
 
 public class RequestKeyV2Codec implements RequestKeyCodec {
-  protected static final ByteString RAW_KEY_PREFIX = ByteString.copyFromUtf8("r");
+  protected static final ByteString RAW_KEY_PREFIX = ByteString.copyFromUtf8("r")
+      .concat(ByteString.copyFrom(new byte[]{0}));
   protected static final ByteString RAW_END_KEY =
-      ByteString.copyFrom(new byte[] {(byte) (RAW_KEY_PREFIX.toByteArray()[0] + 1)});
+      ByteString.copyFrom(new byte[]{(byte) (RAW_KEY_PREFIX.toByteArray()[0] + 1)});
 
-  protected static final ByteString TXN_KEY_PREFIX = ByteString.copyFromUtf8("x");
+  protected static final ByteString TXN_KEY_PREFIX = ByteString.copyFromUtf8("x")
+      .concat(ByteString.copyFrom(new byte[]{0}));
   protected static final ByteString TXN_END_KEY =
-      ByteString.copyFrom(new byte[] {(byte) (TXN_KEY_PREFIX.toByteArray()[0] + 1)});
+      ByteString.copyFrom(new byte[]{(byte) (TXN_KEY_PREFIX.toByteArray()[0] + 1)});
   protected ByteString keyPrefix;
 
   protected ByteString infiniteEndKey;
@@ -49,7 +51,7 @@ public class RequestKeyV2Codec implements RequestKeyCodec {
       throw new IllegalArgumentException("key corrupted, wrong prefix");
     }
 
-    return key.substring(1);
+    return key.substring(keyPrefix.size());
   }
 
   @Override

--- a/src/main/java/org/tikv/common/apiversion/RequestKeyV2Codec.java
+++ b/src/main/java/org/tikv/common/apiversion/RequestKeyV2Codec.java
@@ -23,17 +23,11 @@ import org.tikv.kvproto.Metapb;
 import org.tikv.kvproto.Metapb.Region;
 
 public class RequestKeyV2Codec implements RequestKeyCodec {
-  protected static final ByteString RAW_KEY_PREFIX =
-      ByteString.copyFromUtf8("r").concat(ByteString.copyFrom(new byte[] {0}));
-  protected static final ByteString RAW_END_KEY =
-      ByteString.copyFrom(new byte[] {(byte) (RAW_KEY_PREFIX.toByteArray()[0] + 1)});
-
-  protected static final ByteString TXN_KEY_PREFIX =
-      ByteString.copyFromUtf8("x").concat(ByteString.copyFrom(new byte[] {0}));
-  protected static final ByteString TXN_END_KEY =
-      ByteString.copyFrom(new byte[] {(byte) (TXN_KEY_PREFIX.toByteArray()[0] + 1)});
+  protected static final ByteString RAW_KEY_PREFIX = ByteString.copyFrom(new byte[] {'r', 0});
+  protected static final ByteString RAW_END_KEY = ByteString.copyFrom(new byte[] {'r', 1});
+  protected static final ByteString TXN_KEY_PREFIX = ByteString.copyFrom(new byte[] {'x', 0});
+  protected static final ByteString TXN_END_KEY = ByteString.copyFrom(new byte[] {'x', 1});
   protected ByteString keyPrefix;
-
   protected ByteString infiniteEndKey;
 
   @Override

--- a/src/main/java/org/tikv/common/apiversion/RequestKeyV2Codec.java
+++ b/src/main/java/org/tikv/common/apiversion/RequestKeyV2Codec.java
@@ -23,10 +23,14 @@ import org.tikv.kvproto.Metapb;
 import org.tikv.kvproto.Metapb.Region;
 
 public class RequestKeyV2Codec implements RequestKeyCodec {
-  protected static final ByteString RAW_KEY_PREFIX = ByteString.copyFrom(new byte[] {'r', 0});
-  protected static final ByteString RAW_END_KEY = ByteString.copyFrom(new byte[] {'r', 1});
-  protected static final ByteString TXN_KEY_PREFIX = ByteString.copyFrom(new byte[] {'x', 0});
-  protected static final ByteString TXN_END_KEY = ByteString.copyFrom(new byte[] {'x', 1});
+  protected static final ByteString RAW_DEFAULT_PREFIX =
+      ByteString.copyFrom(new byte[] {'r', 0, 0, 0});
+  protected static final ByteString RAW_DEFAULT_END =
+      ByteString.copyFrom(new byte[] {'r', 0, 0, 1});
+  protected static final ByteString TXN_DEFAULT_PREFIX =
+      ByteString.copyFrom(new byte[] {'x', 0, 0, 0});
+  protected static final ByteString TXN_DEFAULT_END =
+      ByteString.copyFrom(new byte[] {'x', 0, 0, 1});
   protected ByteString keyPrefix;
   protected ByteString infiniteEndKey;
 

--- a/src/main/java/org/tikv/common/apiversion/RequestKeyV2Codec.java
+++ b/src/main/java/org/tikv/common/apiversion/RequestKeyV2Codec.java
@@ -23,15 +23,15 @@ import org.tikv.kvproto.Metapb;
 import org.tikv.kvproto.Metapb.Region;
 
 public class RequestKeyV2Codec implements RequestKeyCodec {
-  protected static final ByteString RAW_KEY_PREFIX = ByteString.copyFromUtf8("r")
-      .concat(ByteString.copyFrom(new byte[]{0}));
+  protected static final ByteString RAW_KEY_PREFIX =
+      ByteString.copyFromUtf8("r").concat(ByteString.copyFrom(new byte[] {0}));
   protected static final ByteString RAW_END_KEY =
-      ByteString.copyFrom(new byte[]{(byte) (RAW_KEY_PREFIX.toByteArray()[0] + 1)});
+      ByteString.copyFrom(new byte[] {(byte) (RAW_KEY_PREFIX.toByteArray()[0] + 1)});
 
-  protected static final ByteString TXN_KEY_PREFIX = ByteString.copyFromUtf8("x")
-      .concat(ByteString.copyFrom(new byte[]{0}));
+  protected static final ByteString TXN_KEY_PREFIX =
+      ByteString.copyFromUtf8("x").concat(ByteString.copyFrom(new byte[] {0}));
   protected static final ByteString TXN_END_KEY =
-      ByteString.copyFrom(new byte[]{(byte) (TXN_KEY_PREFIX.toByteArray()[0] + 1)});
+      ByteString.copyFrom(new byte[] {(byte) (TXN_KEY_PREFIX.toByteArray()[0] + 1)});
   protected ByteString keyPrefix;
 
   protected ByteString infiniteEndKey;

--- a/src/main/java/org/tikv/common/apiversion/RequestKeyV2RawCodec.java
+++ b/src/main/java/org/tikv/common/apiversion/RequestKeyV2RawCodec.java
@@ -21,7 +21,7 @@ public class RequestKeyV2RawCodec extends RequestKeyV2Codec {
   public RequestKeyV2RawCodec() {
     super();
 
-    this.keyPrefix = RAW_KEY_PREFIX;
-    this.infiniteEndKey = RAW_END_KEY;
+    this.keyPrefix = RAW_DEFAULT_PREFIX;
+    this.infiniteEndKey = RAW_DEFAULT_END;
   }
 }

--- a/src/main/java/org/tikv/common/apiversion/RequestKeyV2TxnCodec.java
+++ b/src/main/java/org/tikv/common/apiversion/RequestKeyV2TxnCodec.java
@@ -21,7 +21,7 @@ public class RequestKeyV2TxnCodec extends RequestKeyV2Codec {
   public RequestKeyV2TxnCodec() {
     super();
 
-    this.keyPrefix = TXN_KEY_PREFIX;
-    this.infiniteEndKey = TXN_END_KEY;
+    this.keyPrefix = TXN_DEFAULT_PREFIX;
+    this.infiniteEndKey = TXN_DEFAULT_END;
   }
 }

--- a/src/test/java/org/tikv/common/apiversion/RequestKeyCodecTest.java
+++ b/src/test/java/org/tikv/common/apiversion/RequestKeyCodecTest.java
@@ -164,8 +164,10 @@ public class RequestKeyCodecTest {
     end = ByteString.EMPTY;
     range = v2.encodeRange(start, end);
     assertEquals(v2.encodeKey(start), range.first);
-    byte[] min = v2.encodeKey(ByteString.EMPTY).toByteArray();
-    assertArrayEquals(new byte[] {min[0], (byte) (min[1] + 1)}, range.second.toByteArray());
+
+    byte[] max = v2.encodeKey(ByteString.EMPTY).toByteArray();
+    max[max.length - 1] += 1;
+    assertArrayEquals(max, range.second.toByteArray());
 
     region =
         Region.newBuilder()

--- a/src/test/java/org/tikv/common/apiversion/RequestKeyCodecTest.java
+++ b/src/test/java/org/tikv/common/apiversion/RequestKeyCodecTest.java
@@ -164,9 +164,8 @@ public class RequestKeyCodecTest {
     end = ByteString.EMPTY;
     range = v2.encodeRange(start, end);
     assertEquals(v2.encodeKey(start), range.first);
-    assertArrayEquals(
-        new byte[] {(byte) (v2.encodeKey(ByteString.EMPTY).byteAt(0) + 1)},
-        range.second.toByteArray());
+    byte[] min = v2.encodeKey(ByteString.EMPTY).toByteArray();
+    assertArrayEquals(new byte[] {min[0], (byte) (min[1] + 1)}, range.second.toByteArray());
 
     region =
         Region.newBuilder()


### PR DESCRIPTION
Signed-off-by: iosmanthus <myosmanthustree@gmail.com>

<!-- Thank you for contributing to TiKV Java Client!

PR Title Format: "[close/to/fix #issue_number] summary" -->

### What problem does this PR solve?

Issue Number: close #issue_number

Problem Description: Current key prefix of API v2 is not extensible enough, because no more keyspace information could be attached to it which is against the original design for the https://github.com/tikv/rfcs/blob/master/text/0069-api-v2.md.

### What is changed and how does it work?

 This pull request adds a reserved zero to represent the `default` keyspace.

### Check List for Tests

This PR has been tested by at least one of the following methods:
- Unit test
- Integration test

