### PR TITLE
fix TLS reload doesn't work after delete cert file

### DIFF
--- a/src/main/java/org/tikv/common/util/ChannelFactory.java
+++ b/src/main/java/org/tikv/common/util/ChannelFactory.java
@@ -97,7 +97,7 @@ public class ChannelFactory implements AutoCloseable {
           onChange.run();
         }
       } catch (Exception e) {
-        logger.error("Failed to reload cert!" + e);
+        logger.error("Failed to reload cert!", e);
       }
     }
 
@@ -194,7 +194,7 @@ public class ChannelFactory implements AutoCloseable {
           builder.keyManager(new File(chainPath), new File(keyPath));
         }
       } catch (Exception e) {
-        logger.error("PEM SSL context builder failed!", e);
+        logger.error("Failed to create ssl context builder", e);
         throw new IllegalArgumentException(e);
       }
       return builder;

--- a/src/main/java/org/tikv/common/util/ChannelFactory.java
+++ b/src/main/java/org/tikv/common/util/ChannelFactory.java
@@ -362,7 +362,9 @@ public class ChannelFactory implements AutoCloseable {
 
     if (certContext != null) {
       recycler.shutdown();
-      certWatcher.close();
+      if (certWatcher != null) {
+        certWatcher.close();
+      }
     }
   }
 }

--- a/src/main/java/org/tikv/common/util/ChannelFactory.java
+++ b/src/main/java/org/tikv/common/util/ChannelFactory.java
@@ -89,9 +89,15 @@ public class ChannelFactory implements AutoCloseable {
           this::tryReload, pollInterval, pollInterval, TimeUnit.SECONDS);
     }
 
+    // If any execution of the task encounters an exception, subsequent executions are suppressed.
     private void tryReload() {
-      if (needReload()) {
-        onChange.run();
+      // Add exception handling to avoid schedule stop.
+      try {
+        if (needReload()) {
+          onChange.run();
+        }
+      } catch (Exception e) {
+        logger.error("Failed to reload cert!" + e);
       }
     }
 
@@ -180,11 +186,16 @@ public class ChannelFactory implements AutoCloseable {
     @Override
     public SslContextBuilder createSslContextBuilder() {
       SslContextBuilder builder = GrpcSslContexts.forClient();
-      if (trustPath != null) {
-        builder.trustManager(new File(trustPath));
-      }
-      if (chainPath != null && keyPath != null) {
-        builder.keyManager(new File(chainPath), new File(keyPath));
+      try {
+        if (trustPath != null) {
+          builder.trustManager(new File(trustPath));
+        }
+        if (chainPath != null && keyPath != null) {
+          builder.keyManager(new File(chainPath), new File(keyPath));
+        }
+      } catch (Exception e) {
+        logger.error("PEM SSL context builder failed!", e);
+        throw new IllegalArgumentException(e);
       }
       return builder;
     }

--- a/src/test/java/org/tikv/common/ChannelFactoryTest.java
+++ b/src/test/java/org/tikv/common/ChannelFactoryTest.java
@@ -71,7 +71,6 @@ public class ChannelFactoryTest {
         .scheduleAtFixedRate(
             () -> {
               timesOfFakeTask.getAndIncrement();
-              System.out.println("Execute fake task for the " + timesOfFakeTask.get() + " times.");
               throw new RuntimeException("Mock exception in fake task");
             },
             1,
@@ -84,7 +83,6 @@ public class ChannelFactoryTest {
         () -> {
           timesOfReloadTask.getAndIncrement();
           touchCert();
-          System.out.println("Execute reload task for the " + timesOfReloadTask.get() + " times.");
           throw new RuntimeException("Mock exception in reload task");
         });
 

--- a/src/test/java/org/tikv/common/ChannelFactoryTest.java
+++ b/src/test/java/org/tikv/common/ChannelFactoryTest.java
@@ -25,7 +25,10 @@ import io.grpc.ManagedChannel;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.Test;
 import org.tikv.common.util.ChannelFactory;
@@ -57,6 +60,38 @@ public class ChannelFactoryTest {
     new CertWatcher(2, ImmutableList.of(a, b, c), () -> changed.set(true));
     Thread.sleep(5000);
     assertTrue(changed.get());
+  }
+
+  @Test
+  public void testCertWatcherWithExceptionTask() throws InterruptedException {
+    AtomicInteger timesOfReloadTask = new AtomicInteger(0);
+    AtomicInteger timesOfFakeTask = new AtomicInteger(0);
+
+    Executors.newSingleThreadScheduledExecutor()
+        .scheduleAtFixedRate(
+            () -> {
+              timesOfFakeTask.getAndIncrement();
+              System.out.println("Execute fake task for the " + timesOfFakeTask.get() + " times.");
+              throw new RuntimeException("Mock exception in fake task");
+            },
+            1,
+            1,
+            TimeUnit.SECONDS);
+
+    new CertWatcher(
+        1,
+        ImmutableList.of(new File(caPath), new File(clientCertPath), new File(clientKeyPath)),
+        () -> {
+          timesOfReloadTask.getAndIncrement();
+          touchCert();
+          System.out.println("Execute reload task for the " + timesOfReloadTask.get() + " times.");
+          throw new RuntimeException("Mock exception in reload task");
+        });
+
+    Thread.sleep(5000);
+
+    assertTrue(timesOfFakeTask.get() == 1);
+    assertTrue(timesOfReloadTask.get() > 1);
   }
 
   @Test

--- a/src/test/java/org/tikv/common/ChannelFactoryTest.java
+++ b/src/test/java/org/tikv/common/ChannelFactoryTest.java
@@ -25,8 +25,6 @@ import io.grpc.ManagedChannel;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;

--- a/src/test/java/org/tikv/common/ChannelFactoryTest.java
+++ b/src/test/java/org/tikv/common/ChannelFactoryTest.java
@@ -65,18 +65,6 @@ public class ChannelFactoryTest {
   @Test
   public void testCertWatcherWithExceptionTask() throws InterruptedException {
     AtomicInteger timesOfReloadTask = new AtomicInteger(0);
-    AtomicInteger timesOfFakeTask = new AtomicInteger(0);
-
-    Executors.newSingleThreadScheduledExecutor()
-        .scheduleAtFixedRate(
-            () -> {
-              timesOfFakeTask.getAndIncrement();
-              throw new RuntimeException("Mock exception in fake task");
-            },
-            1,
-            1,
-            TimeUnit.SECONDS);
-
     new CertWatcher(
         1,
         ImmutableList.of(new File(caPath), new File(clientCertPath), new File(clientKeyPath)),
@@ -87,8 +75,6 @@ public class ChannelFactoryTest {
         });
 
     Thread.sleep(5000);
-
-    assertTrue(timesOfFakeTask.get() == 1);
     assertTrue(timesOfReloadTask.get() > 1);
   }
 


### PR DESCRIPTION
Signed-off-by: Daemonxiao <735462752@qq.com>

<!-- Thank you for contributing to TiKV Java Client!

PR Title Format: "[close/to/fix #issue_number] summary" -->

### What problem does this PR solve?

TiSpark met some [problem](https://github.com/pingcap/tispark/issues/2376) when use TLS Reload.

Problem Description: tryReload() is used as a task in ScheduledFuture. When tryReload() throws an exception, the schedule will be suppressed which makes tryReload() will not work.


### What is changed and how does it work?
Add try-catch in tryReload().
```
    // If any execution of the task encounters an exception, subsequent executions are suppressed.
    private void tryReload() {
      // Add exception handling to avoid schedule stop.
      try {
        if (needReload()) {
          onChange.run();
        }
      } catch (Exception e) {
        logger.error("Failed to reload cert!" + e);
      }
    }
```

### Code changes

<!-- REMOVE the items that are not applicable -->
- Has exported function/method change

### Check List for Tests

This PR has been tested by at least one of the following methods:
- Unit test
- Integration test

### Side effects
- NO side effects

### Related changes
- Need to cherry-pick to the release branch
