### PR TITLE
[fix #623] region may be missed

### DIFF
--- a/src/main/java/org/tikv/common/operation/iterator/ConcreteScanIterator.java
+++ b/src/main/java/org/tikv/common/operation/iterator/ConcreteScanIterator.java
@@ -77,6 +77,10 @@ public class ConcreteScanIterator extends ScanIterator {
       client.setTimeout(conf.getScanTimeout());
       BackOffer backOffer = ConcreteBackOffer.newScannerNextMaxBackOff();
       currentCache = client.scan(backOffer, startKey, version);
+      // If we get region before scan, we will use region from cache which
+      // may have wrong end key. This may miss some regions that split from old region.
+      // Client will get the newest region during scan. So we need to
+      // update region after scan.
       region = client.getRegion();
       return region;
     }

--- a/src/main/java/org/tikv/common/operation/iterator/ConcreteScanIterator.java
+++ b/src/main/java/org/tikv/common/operation/iterator/ConcreteScanIterator.java
@@ -75,9 +75,9 @@ public class ConcreteScanIterator extends ScanIterator {
     TiRegion region;
     try (RegionStoreClient client = builder.build(startKey)) {
       client.setTimeout(conf.getScanTimeout());
-      region = client.getRegion();
       BackOffer backOffer = ConcreteBackOffer.newScannerNextMaxBackOff();
       currentCache = client.scan(backOffer, startKey, version);
+      region = client.getRegion();
       return region;
     }
   }

--- a/src/main/java/org/tikv/common/operation/iterator/RawScanIterator.java
+++ b/src/main/java/org/tikv/common/operation/iterator/RawScanIterator.java
@@ -57,6 +57,9 @@ public class RawScanIterator extends ScanIterator {
         } else {
           try {
             currentCache = client.rawScan(backOffer, startKey, limit, keyOnly);
+            // Client will get the newest region during scan. So we need to
+            // update region after scan.
+            region = client.getRegion();
           } catch (final TiKVException e) {
             backOffer.doBackOff(BackOffFunction.BackOffFuncType.BoRegionMiss, e);
             continue;

--- a/src/main/java/org/tikv/common/operation/iterator/ScanIterator.java
+++ b/src/main/java/org/tikv/common/operation/iterator/ScanIterator.java
@@ -65,6 +65,8 @@ public abstract class ScanIterator implements Iterator<Kvrpcpb.KvPair> {
    *
    * @return TiRegion of current data loaded to cache
    * @throws GrpcException if scan still fails after backoff
+   *
+   * TODO : Add test to check it correctness
    */
   abstract TiRegion loadCurrentRegionToCache() throws GrpcException;
 

--- a/src/main/java/org/tikv/common/operation/iterator/ScanIterator.java
+++ b/src/main/java/org/tikv/common/operation/iterator/ScanIterator.java
@@ -65,8 +65,7 @@ public abstract class ScanIterator implements Iterator<Kvrpcpb.KvPair> {
    *
    * @return TiRegion of current data loaded to cache
    * @throws GrpcException if scan still fails after backoff
-   *
-   * TODO : Add test to check it correctness
+   *     <p>TODO : Add test to check it correctness
    */
   abstract TiRegion loadCurrentRegionToCache() throws GrpcException;
 

--- a/src/main/java/org/tikv/common/region/RegionStoreClient.java
+++ b/src/main/java/org/tikv/common/region/RegionStoreClient.java
@@ -1253,6 +1253,9 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
               regionManager, this, resp -> resp.hasRegionError() ? resp.getRegionError() : null);
       RawScanResponse resp =
           callWithRetry(backOffer, TikvGrpc.getRawScanMethod(), factory, handler);
+      // RegionErrorHandler may refresh region cache due to outdated region info,
+      // This region need to get newest ino from cache.
+      region = regionManager.getRegionByKey(key, backOffer);
       return rawScanHelper(resp);
     } finally {
       requestTimer.observeDuration();

--- a/src/main/java/org/tikv/common/region/RegionStoreClient.java
+++ b/src/main/java/org/tikv/common/region/RegionStoreClient.java
@@ -339,9 +339,6 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
       BackOffer backOffer, ByteString startKey, long version, boolean keyOnly) {
     boolean forWrite = false;
     while (true) {
-      // we should refresh region
-      region = regionManager.getRegionByKey(startKey, backOffer);
-
       Supplier<ScanRequest> request =
           () ->
               ScanRequest.newBuilder()
@@ -365,6 +362,10 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
               version,
               forWrite);
       ScanResponse resp = callWithRetry(backOffer, TikvGrpc.getKvScanMethod(), request, handler);
+      // retry may refresh region info
+      // we need to update region after retry
+      region = regionManager.getRegionByKey(startKey, backOffer);
+
       if (isScanSuccess(backOffer, resp)) {
         return doScan(resp);
       }

--- a/src/main/java/org/tikv/common/region/RegionStoreClient.java
+++ b/src/main/java/org/tikv/common/region/RegionStoreClient.java
@@ -1254,7 +1254,7 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
       RawScanResponse resp =
           callWithRetry(backOffer, TikvGrpc.getRawScanMethod(), factory, handler);
       // RegionErrorHandler may refresh region cache due to outdated region info,
-      // This region need to get newest ino from cache.
+      // This region need to get newest info from cache.
       region = regionManager.getRegionByKey(key, backOffer);
       return rawScanHelper(resp);
     } finally {


### PR DESCRIPTION
<!-- Thank you for contributing to TiKV Java Client!

PR Title Format: "[close/to/fix #issue_number] summary" -->

### What problem does this PR solve?

Issue Number: close #623

Problem Description: If there is a region split between two queries, it may miss some regions.

### What is changed and how does it work?
I change the time of getting region from before scan to after scan.

When we build client, we will use region info in regionCache. After region split, it's outdated.
But when client try to scan the region, it will get the newest region info from pb. 

In the original code, we get region info before scan. So the region info is still outdated and it will use the old endKey to get next region. Using the old endKey may miss some regions that split during the two query.

I get the region info after scan to make sure the return value is newest.


### Check List for Tests

This PR has been tested by at least one of the following methods:
- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
