### PR TITLE
Update license-checker.yml

### DIFF
--- a/.github/workflows/license-checker.yml
+++ b/.github/workflows/license-checker.yml
@@ -15,10 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Check License Header
-        uses: apache/skywalking-eyes@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: apache/skywalking-eyes/header@501a28d2fb4a9b962661987e50cf0219631b32ff
         with:
-          log: info
           config: .github/license-checker.yml
 


### PR DESCRIPTION
We have a dedicate GitHub actions for header check so this should be updated, and we don't recommend using `@main` so there is no unexpected behaviors when we have changes in our codebase.

See https://github.com/apache/skywalking-eyes/pull/123