### PR TITLE
[close #635] constraint the getMember timeout by inject a backoffer

### DIFF
--- a/src/main/java/org/tikv/common/AbstractGRPCClient.java
+++ b/src/main/java/org/tikv/common/AbstractGRPCClient.java
@@ -198,8 +198,7 @@ public abstract class AbstractGRPCClient<
     }
   }
 
-  protected boolean checkHealth(String addressStr, HostMapping hostMapping) {
-    BackOffer backOffer = ConcreteBackOffer.newCustomBackOff((int) (timeout * 2));
+  protected boolean checkHealth(BackOffer backOffer, String addressStr, HostMapping hostMapping) {
     try {
       return doCheckHealth(backOffer, addressStr, hostMapping);
     } catch (Exception e) {

--- a/src/main/java/org/tikv/common/AbstractGRPCClient.java
+++ b/src/main/java/org/tikv/common/AbstractGRPCClient.java
@@ -40,7 +40,6 @@ import org.tikv.common.streaming.StreamingResponse;
 import org.tikv.common.util.BackOffFunction.BackOffFuncType;
 import org.tikv.common.util.BackOffer;
 import org.tikv.common.util.ChannelFactory;
-import org.tikv.common.util.ConcreteBackOffer;
 
 public abstract class AbstractGRPCClient<
         BlockingStubT extends AbstractStub<BlockingStubT>,

--- a/src/main/java/org/tikv/common/PDClient.java
+++ b/src/main/java/org/tikv/common/PDClient.java
@@ -498,7 +498,8 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDFutureStub>
     return true;
   }
 
-  synchronized boolean createFollowerClientWrapper(BackOffer backOffer, String followerUrlStr, String leaderUrls) {
+  synchronized boolean createFollowerClientWrapper(
+      BackOffer backOffer, String followerUrlStr, String leaderUrls) {
     // TODO: Why not strip protocol info on server side since grpc does not need it
 
     try {
@@ -535,7 +536,8 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDFutureStub>
       leaderUrlStr = uriToAddr(addrToUri(leaderUrlStr));
 
       // if leader is switched, just return.
-      if (checkHealth(backOffer, leaderUrlStr, hostMapping) && createLeaderClientWrapper(leaderUrlStr)) {
+      if (checkHealth(backOffer, leaderUrlStr, hostMapping)
+          && createLeaderClientWrapper(leaderUrlStr)) {
         lastUpdateLeaderTime = System.currentTimeMillis();
         return;
       }
@@ -562,7 +564,8 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDFutureStub>
           hasReachNextMember = true;
           continue;
         }
-        if (hasReachNextMember && createFollowerClientWrapper(backOffer, followerUrlStr, leaderUrlStr)) {
+        if (hasReachNextMember
+            && createFollowerClientWrapper(backOffer, followerUrlStr, leaderUrlStr)) {
           logger.warn(
               String.format("forward request to pd [%s] by pd [%s]", leaderUrlStr, followerUrlStr));
           return;
@@ -592,7 +595,8 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDFutureStub>
       leaderUrlStr = uriToAddr(addrToUri(leaderUrlStr));
 
       // If leader is not change but becomes available, we can cancel follower forward.
-      if (checkHealth(defaultBackOffer(), leaderUrlStr, hostMapping) && trySwitchLeader(leaderUrlStr)) {
+      if (checkHealth(defaultBackOffer(), leaderUrlStr, hostMapping)
+          && trySwitchLeader(leaderUrlStr)) {
         if (!urls.equals(this.pdAddrs)) {
           tryUpdateMembers(urls);
         }

--- a/src/main/java/org/tikv/common/PDClient.java
+++ b/src/main/java/org/tikv/common/PDClient.java
@@ -581,8 +581,9 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDFutureStub>
 
   public void tryUpdateLeader() {
     for (URI url : this.pdAddrs) {
+      BackOffer backOffer = defaultBackOffer();
       // since resp is null, we need update leader's address by walking through all pd server.
-      GetMembersResponse resp = getMembers(defaultBackOffer(), url);
+      GetMembersResponse resp = getMembers(backOffer, url);
       if (resp == null) {
         continue;
       }
@@ -595,8 +596,7 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDFutureStub>
       leaderUrlStr = uriToAddr(addrToUri(leaderUrlStr));
 
       // If leader is not change but becomes available, we can cancel follower forward.
-      if (checkHealth(defaultBackOffer(), leaderUrlStr, hostMapping)
-          && trySwitchLeader(leaderUrlStr)) {
+      if (checkHealth(backOffer, leaderUrlStr, hostMapping) && trySwitchLeader(leaderUrlStr)) {
         if (!urls.equals(this.pdAddrs)) {
           tryUpdateMembers(urls);
         }

--- a/src/main/java/org/tikv/common/operation/PDErrorHandler.java
+++ b/src/main/java/org/tikv/common/operation/PDErrorHandler.java
@@ -59,7 +59,7 @@ public class PDErrorHandler<RespT> implements ErrorHandler<RespT> {
         case PD_ERROR:
           backOffer.doBackOff(
               BackOffFunction.BackOffFuncType.BoPDRPC, new GrpcException(error.toString()));
-          client.updateLeaderOrForwardFollower();
+          client.updateLeaderOrForwardFollower(backOffer);
           return true;
         case REGION_PEER_NOT_ELECTED:
           logger.debug(error.getMessage());
@@ -80,7 +80,7 @@ public class PDErrorHandler<RespT> implements ErrorHandler<RespT> {
       return false;
     }
     backOffer.doBackOff(BackOffFunction.BackOffFuncType.BoPDRPC, e);
-    client.updateLeaderOrForwardFollower();
+    client.updateLeaderOrForwardFollower(backOffer);
     return true;
   }
 }

--- a/src/test/java/org/tikv/common/PDMockServerTest.java
+++ b/src/test/java/org/tikv/common/PDMockServerTest.java
@@ -20,6 +20,7 @@ package org.tikv.common;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
 import org.junit.After;
 import org.junit.Before;
 import org.tikv.common.TiConfiguration.ApiVersion;
@@ -49,6 +50,16 @@ public abstract class PDMockServerTest {
     session.close();
 
     session = TiSession.create(conf);
+  }
+
+  void updateConf(Function<TiConfiguration, TiConfiguration> update) throws Exception {
+    if (session == null) {
+      throw new IllegalStateException("Cluster is not initialized");
+    }
+
+    session.close();
+
+    session = TiSession.create(update.apply(session.getConf()));
   }
 
   void setup(String addr) throws IOException {

--- a/src/test/java/org/tikv/common/TimeoutTest.java
+++ b/src/test/java/org/tikv/common/TimeoutTest.java
@@ -54,7 +54,7 @@ public class TimeoutTest extends MockThreeStoresTest {
       long start = System.currentTimeMillis();
       client.get(ByteString.copyFromUtf8("key"));
       long end = System.currentTimeMillis();
-      Assert.assertTrue(end - start < 500);
+      Assert.assertTrue(end - start < session.getConf().getRawKVReadTimeoutInMS() * 2L);
     }
   }
 }

--- a/src/test/java/org/tikv/common/TimeoutTest.java
+++ b/src/test/java/org/tikv/common/TimeoutTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 TiKV Project Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.tikv.common;
+
+import com.google.protobuf.ByteString;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.tikv.raw.RawKVClient;
+
+public class TimeoutTest extends MockThreeStoresTest {
+  @Before
+  public void init() throws Exception {
+    updateConf(conf -> {
+      conf.setEnableAtomicForCAS(true);
+      conf.setTimeout(150);
+      conf.setForwardTimeout(200);
+      conf.setRawKVReadTimeoutInMS(400);
+      conf.setRawKVWriteTimeoutInMS(400);
+      conf.setRawKVBatchReadTimeoutInMS(400);
+      conf.setRawKVBatchWriteTimeoutInMS(400);
+      conf.setRawKVWriteSlowLogInMS(50);
+      conf.setRawKVReadSlowLogInMS(50);
+      conf.setRawKVBatchReadSlowLogInMS(50);
+      conf.setRawKVBatchWriteSlowLogInMS(50);
+      return conf;
+    });
+  }
+
+  private RawKVClient createClient() {
+    return session.createRawClient();
+  }
+
+  @Test
+  public void testTimeoutInTime() {
+    try (RawKVClient client = createClient()) {
+      pdServers.get(0).stop();
+      long start = System.currentTimeMillis();
+      client.get(ByteString.copyFromUtf8("key"));
+      long end = System.currentTimeMillis();
+      Assert.assertTrue(end - start < 500);
+    }
+  }
+}

--- a/src/test/java/org/tikv/common/TimeoutTest.java
+++ b/src/test/java/org/tikv/common/TimeoutTest.java
@@ -26,20 +26,21 @@ import org.tikv.raw.RawKVClient;
 public class TimeoutTest extends MockThreeStoresTest {
   @Before
   public void init() throws Exception {
-    updateConf(conf -> {
-      conf.setEnableAtomicForCAS(true);
-      conf.setTimeout(150);
-      conf.setForwardTimeout(200);
-      conf.setRawKVReadTimeoutInMS(400);
-      conf.setRawKVWriteTimeoutInMS(400);
-      conf.setRawKVBatchReadTimeoutInMS(400);
-      conf.setRawKVBatchWriteTimeoutInMS(400);
-      conf.setRawKVWriteSlowLogInMS(50);
-      conf.setRawKVReadSlowLogInMS(50);
-      conf.setRawKVBatchReadSlowLogInMS(50);
-      conf.setRawKVBatchWriteSlowLogInMS(50);
-      return conf;
-    });
+    updateConf(
+        conf -> {
+          conf.setEnableAtomicForCAS(true);
+          conf.setTimeout(150);
+          conf.setForwardTimeout(200);
+          conf.setRawKVReadTimeoutInMS(400);
+          conf.setRawKVWriteTimeoutInMS(400);
+          conf.setRawKVBatchReadTimeoutInMS(400);
+          conf.setRawKVBatchWriteTimeoutInMS(400);
+          conf.setRawKVWriteSlowLogInMS(50);
+          conf.setRawKVReadSlowLogInMS(50);
+          conf.setRawKVBatchReadSlowLogInMS(50);
+          conf.setRawKVBatchWriteSlowLogInMS(50);
+          return conf;
+        });
   }
 
   private RawKVClient createClient() {


### PR DESCRIPTION
Signed-off-by: iosmanthus <myosmanthustree@gmail.com>

<!-- Thank you for contributing to TiKV Java Client!

PR Title Format: "[close/to/fix #issue_number] summary" -->

### What problem does this PR solve?

Issue Number: close #635

Problem Description:

The `getMembers` is not limited by a `backoffer`, which might cause the exception will not throw in time. For example, a user might set the timeout of a request to 400ms, but if the PD is disconnected, the `getMembers` might sleep more than 400ms since the `backoffer` it used is not passed from the upper code.

### What is changed and how does it work?

Inject a `backoffer` for `getMembers` and check timeout before acquiring a channel from the pool.


### Check List for Tests

This PR has been tested by at least one of the following methods:
- Unit test


### Related changes

<!-- REMOVE the items that are not applicable -->
- Need to cherry-pick the release branch

