### PR TITLE
[close #639] reduce lock granularity of RegionStoreClient and PDClient

### DIFF
--- a/src/main/java/org/tikv/common/AbstractGRPCClient.java
+++ b/src/main/java/org/tikv/common/AbstractGRPCClient.java
@@ -33,7 +33,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.tikv.common.log.SlowLogSpan;
 import org.tikv.common.operation.ErrorHandler;
 import org.tikv.common.policy.RetryMaxMs.Builder;
 import org.tikv.common.policy.RetryPolicy;
@@ -201,13 +200,6 @@ public abstract class AbstractGRPCClient<
   }
 
   protected boolean checkHealth(BackOffer backOffer, String addressStr, HostMapping hostMapping) {
-    SlowLogSpan checkHealthSpan = backOffer.getSlowLog().start("check_health");
-    try {
-      return doCheckHealth(backOffer, addressStr, hostMapping);
-    } catch (Exception e) {
-      return false;
-    } finally {
-      checkHealthSpan.end();
-    }
+    return doCheckHealth(backOffer, addressStr, hostMapping);
   }
 }

--- a/src/main/java/org/tikv/common/PDClient.java
+++ b/src/main/java/org/tikv/common/PDClient.java
@@ -523,8 +523,8 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDFutureStub>
 
   public void tryUpdateLeaderOrForwardFollower() {
     if (updateLeaderNotify.compareAndSet(false, true)) {
-      BackOffer backOffer = ConcreteBackOffer.newCustomBackOff(BackOffer.PD_INFO_BACKOFF);
       try {
+        BackOffer backOffer = defaultBackOffer();
         updateLeaderService.submit(
             () -> {
               try {

--- a/src/main/java/org/tikv/common/operation/PDErrorHandler.java
+++ b/src/main/java/org/tikv/common/operation/PDErrorHandler.java
@@ -62,7 +62,7 @@ public class PDErrorHandler<RespT> implements ErrorHandler<RespT> {
               BackOffFunction.BackOffFuncType.BoPDRPC, new GrpcException(error.toString()));
           SlowLogSpan tryUpdateLeaderSpan = backOffer.getSlowLog().start("try_update_leader");
           try {
-            client.tryUpdateLeaderOrForwardFollower(backOffer);
+            client.tryUpdateLeaderOrForwardFollower();
           } finally {
             tryUpdateLeaderSpan.end();
           }
@@ -86,9 +86,9 @@ public class PDErrorHandler<RespT> implements ErrorHandler<RespT> {
       return false;
     }
     backOffer.doBackOff(BackOffFunction.BackOffFuncType.BoPDRPC, e);
-    SlowLogSpan updateLeaderSpan = backOffer.getSlowLog().start("update_leader");
+    SlowLogSpan updateLeaderSpan = backOffer.getSlowLog().start("try_update_leader");
     try {
-      client.tryUpdateLeaderOrForwardFollower(backOffer);
+      client.tryUpdateLeaderOrForwardFollower();
     } finally {
       updateLeaderSpan.end();
     }

--- a/src/main/java/org/tikv/common/operation/PDErrorHandler.java
+++ b/src/main/java/org/tikv/common/operation/PDErrorHandler.java
@@ -59,7 +59,7 @@ public class PDErrorHandler<RespT> implements ErrorHandler<RespT> {
         case PD_ERROR:
           backOffer.doBackOff(
               BackOffFunction.BackOffFuncType.BoPDRPC, new GrpcException(error.toString()));
-          client.updateLeaderOrForwardFollower();
+          client.updateLeaderOrForwardFollower(backOffer);
           return true;
         case REGION_PEER_NOT_ELECTED:
           logger.debug(error.getMessage());
@@ -80,7 +80,7 @@ public class PDErrorHandler<RespT> implements ErrorHandler<RespT> {
       return false;
     }
     backOffer.doBackOff(BackOffFunction.BackOffFuncType.BoPDRPC, e);
-    client.updateLeaderOrForwardFollower();
+    client.updateLeaderOrForwardFollower(backOffer);
     return true;
   }
 }

--- a/src/main/java/org/tikv/common/region/RegionManager.java
+++ b/src/main/java/org/tikv/common/region/RegionManager.java
@@ -138,8 +138,6 @@ public class RegionManager {
         region =
             cache.putRegion(createRegion(regionAndLeader.first, regionAndLeader.second, backOffer));
       }
-    } catch (Exception e) {
-      return null;
     } finally {
       requestTimer.observeDuration();
       slowLogSpan.end();

--- a/src/main/java/org/tikv/common/region/RegionManager.java
+++ b/src/main/java/org/tikv/common/region/RegionManager.java
@@ -138,6 +138,8 @@ public class RegionManager {
         region =
             cache.putRegion(createRegion(regionAndLeader.first, regionAndLeader.second, backOffer));
       }
+    } catch (Exception e) {
+      return null;
     } finally {
       requestTimer.observeDuration();
       slowLogSpan.end();
@@ -180,7 +182,7 @@ public class RegionManager {
   public Pair<TiRegion, TiStore> getRegionStorePairByKey(
       ByteString key, TiStoreType storeType, BackOffer backOffer) {
     TiRegion region = getRegionByKey(key, backOffer);
-    if (!region.isValid()) {
+    if (region == null || !region.isValid()) {
       throw new TiClientInternalException("Region invalid: " + region);
     }
 

--- a/src/main/java/org/tikv/common/region/RegionStoreClient.java
+++ b/src/main/java/org/tikv/common/region/RegionStoreClient.java
@@ -1408,38 +1408,34 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
           this);
     }
 
-    public synchronized RegionStoreClient build(TiRegion region, TiStore store)
-        throws GrpcException {
+    public RegionStoreClient build(TiRegion region, TiStore store) throws GrpcException {
       return build(region, store, TiStoreType.TiKV);
     }
 
-    public synchronized RegionStoreClient build(ByteString key) throws GrpcException {
+    public RegionStoreClient build(ByteString key) throws GrpcException {
       return build(key, TiStoreType.TiKV);
     }
 
-    public synchronized RegionStoreClient build(ByteString key, BackOffer backOffer)
-        throws GrpcException {
+    public RegionStoreClient build(ByteString key, BackOffer backOffer) throws GrpcException {
       return build(key, TiStoreType.TiKV, backOffer);
     }
 
-    public synchronized RegionStoreClient build(ByteString key, TiStoreType storeType)
-        throws GrpcException {
+    public RegionStoreClient build(ByteString key, TiStoreType storeType) throws GrpcException {
       return build(key, storeType, defaultBackOff());
     }
 
-    public synchronized RegionStoreClient build(
-        ByteString key, TiStoreType storeType, BackOffer backOffer) throws GrpcException {
+    public RegionStoreClient build(ByteString key, TiStoreType storeType, BackOffer backOffer)
+        throws GrpcException {
       Pair<TiRegion, TiStore> pair =
           regionManager.getRegionStorePairByKey(key, storeType, backOffer);
       return build(pair.first, pair.second, storeType);
     }
 
-    public synchronized RegionStoreClient build(TiRegion region) throws GrpcException {
+    public RegionStoreClient build(TiRegion region) throws GrpcException {
       return build(region, defaultBackOff());
     }
 
-    public synchronized RegionStoreClient build(TiRegion region, BackOffer backOffer)
-        throws GrpcException {
+    public RegionStoreClient build(TiRegion region, BackOffer backOffer) throws GrpcException {
       TiStore store = regionManager.getStoreById(region.getLeader().getStoreId(), backOffer);
       return build(region, store, TiStoreType.TiKV);
     }

--- a/src/test/java/org/tikv/common/PDClientV2MockTest.java
+++ b/src/test/java/org/tikv/common/PDClientV2MockTest.java
@@ -88,18 +88,16 @@ public class PDClientV2MockTest extends PDMockServerTest {
     String start = "getRegionById";
     String end = "getRegionByIdEnd";
     leader.addGetRegionByIDListener(request -> makeGetRegionResponse(start, end));
-    try (PDClient client = createClient()) {
-      Metapb.Region r = client.getRegionByID(ConcreteBackOffer.newRawKVBackOff(), 1).first;
-      Assert.assertEquals(start, r.getStartKey().toStringUtf8());
-      Assert.assertEquals(end, r.getEndKey().toStringUtf8());
-    }
+    PDClient client = createClient();
+    Metapb.Region r = client.getRegionByID(ConcreteBackOffer.newRawKVBackOff(), 1).first;
+    Assert.assertEquals(start, r.getStartKey().toStringUtf8());
+    Assert.assertEquals(end, r.getEndKey().toStringUtf8());
 
     leader.addGetRegionByIDListener(request -> makeGetRegionResponse(start, ""));
-    try (PDClient client = createClient()) {
-      Metapb.Region r = client.getRegionByID(ConcreteBackOffer.newRawKVBackOff(), 1).first;
-      Assert.assertEquals(start, r.getStartKey().toStringUtf8());
-      Assert.assertEquals("", r.getEndKey().toStringUtf8());
-    }
+
+    r = client.getRegionByID(ConcreteBackOffer.newRawKVBackOff(), 1).first;
+    Assert.assertEquals(start, r.getStartKey().toStringUtf8());
+    Assert.assertEquals("", r.getEndKey().toStringUtf8());
   }
 
   @Test
@@ -113,15 +111,14 @@ public class PDClientV2MockTest extends PDMockServerTest {
                 .addRegions(Pdpb.Region.newBuilder().setRegion(makeRegion(start, end)).build())
                 .build());
 
-    try (PDClient client = createClient()) {
-      List<Region> regions =
-          client.scanRegions(
-              ConcreteBackOffer.newRawKVBackOff(), ByteString.EMPTY, ByteString.EMPTY, 1);
+    PDClient client = createClient();
+    List<Region> regions =
+        client.scanRegions(
+            ConcreteBackOffer.newRawKVBackOff(), ByteString.EMPTY, ByteString.EMPTY, 1);
 
-      for (Region r : regions) {
-        Assert.assertEquals(start, r.getRegion().getStartKey().toStringUtf8());
-        Assert.assertEquals(end, r.getRegion().getEndKey().toStringUtf8());
-      }
+    for (Region r : regions) {
+      Assert.assertEquals(start, r.getRegion().getStartKey().toStringUtf8());
+      Assert.assertEquals(end, r.getRegion().getEndKey().toStringUtf8());
     }
   }
 }

--- a/src/test/java/org/tikv/common/TimeoutTest.java
+++ b/src/test/java/org/tikv/common/TimeoutTest.java
@@ -52,9 +52,12 @@ public class TimeoutTest extends MockThreeStoresTest {
     try (RawKVClient client = createClient()) {
       pdServers.get(0).stop();
       long start = System.currentTimeMillis();
-      client.get(ByteString.copyFromUtf8("key"));
+      try {
+        client.get(ByteString.copyFromUtf8("key"));
+      } catch (Exception ignore) {
+      }
       long end = System.currentTimeMillis();
-      Assert.assertTrue(end - start < session.getConf().getRawKVReadTimeoutInMS() * 2L);
+      Assert.assertTrue(end - start < (session.getConf().getRawKVReadTimeoutInMS() * 1.5));
     }
   }
 }


### PR DESCRIPTION
Signed-off-by: iosmanthus <myosmanthustree@gmail.com>


### What problem does this PR solve?

Issue Number: close #639

Problem Description:

This pull request tries to reduce the lock granularity of `ReionStoreClient` and `PDClient`, we might block the requests while under a heavy workload.

### What is changed and how does it work?

1. Remove the synchronized keyword for RegionStoreBuilder.build, since the region cache's methods have already been synced.
2. Remove the synchronized keyword in PDClient's update leader logic, since the leader will be eventually updated to the latest one by the update leader scheduler.


### Check List for Tests

This PR has been tested by at least one of the following methods:
- Unit test
- Integration test

### Related changes

<!-- REMOVE the items that are not applicable -->
- Need to cherry-pick the release branch
