### PR TITLE
[close #634] fix rawBatchPut hang while batch size is larger than MAX_RAW_BATCH_LIMIT

### DIFF
--- a/src/main/java/org/tikv/raw/RawKVClient.java
+++ b/src/main/java/org/tikv/raw/RawKVClient.java
@@ -749,17 +749,17 @@ public class RawKVClient implements RawKVClientBase {
     while (!taskQueue.isEmpty()) {
       List<Batch> task = taskQueue.poll();
       for (Batch batch : task) {
-        completionService.submit(
-            () -> doSendBatchPutInBatchesWithRetry(batch.getBackOffer(), batch, ttl));
+        futureList.add(completionService.submit(
+            () -> doSendBatchPutInBatchesWithRetry(batch.getBackOffer(), batch, ttl)));
+      }
 
-        try {
-          getTasks(completionService, taskQueue, task, deadline - System.currentTimeMillis());
-        } catch (Exception e) {
-          for (Future<List<Batch>> future : futureList) {
-            future.cancel(true);
-          }
-          throw e;
+      try {
+        getTasks(completionService, taskQueue, task, deadline - System.currentTimeMillis());
+      } catch (Exception e) {
+        for (Future<List<Batch>> future : futureList) {
+          future.cancel(true);
         }
+        throw e;
       }
     }
   }

--- a/src/main/java/org/tikv/raw/RawKVClient.java
+++ b/src/main/java/org/tikv/raw/RawKVClient.java
@@ -749,8 +749,9 @@ public class RawKVClient implements RawKVClientBase {
     while (!taskQueue.isEmpty()) {
       List<Batch> task = taskQueue.poll();
       for (Batch batch : task) {
-        futureList.add(completionService.submit(
-            () -> doSendBatchPutInBatchesWithRetry(batch.getBackOffer(), batch, ttl)));
+        futureList.add(
+            completionService.submit(
+                () -> doSendBatchPutInBatchesWithRetry(batch.getBackOffer(), batch, ttl)));
       }
 
       try {

--- a/src/test/java/org/tikv/raw/RawKVClientTest.java
+++ b/src/test/java/org/tikv/raw/RawKVClientTest.java
@@ -20,6 +20,7 @@ package org.tikv.raw;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.tikv.raw.RawKVClientBase.MAX_RAW_BATCH_LIMIT;
 
 import com.google.common.collect.ImmutableList;
 import com.google.protobuf.ByteString;
@@ -1086,18 +1087,13 @@ public class RawKVClientTest extends BaseRawKVTest {
   }
 
   @Test
-  public void testBatchPut() throws Exception {
-    TiConfiguration conf = session.getConf();
-    conf.setRawKVBatchWriteTimeoutInMS(100000);
-    conf.setTimeout(100000);
-    try(TiSession newSession = TiSession.create(conf)){
-      try(RawKVClient client=newSession.createRawClient()) {
-        HashMap<ByteString, ByteString> kvs = new HashMap<>();
-        for (int i = 0; i < 2048; i++) {
-          kvs.put(ByteString.copyFromUtf8("key@" + i), rawValue("value@" + i));
-        }
-        client.batchPut(kvs);
-      }
-    };
+  public void testBatchPutForIssue634() {
+    ByteString prefix = ByteString.copyFromUtf8("testBatchPutForIssue634");
+    client.deletePrefix(prefix);
+    HashMap<ByteString, ByteString> kvs = new HashMap<>();
+    for (int i = 0; i < MAX_RAW_BATCH_LIMIT * 4; i++) {
+      kvs.put(prefix.concat(ByteString.copyFromUtf8("key@" + i)), rawValue("value@" + i));
+    }
+    client.batchPut(kvs);
   }
 }

--- a/src/test/java/org/tikv/raw/RawKVClientTest.java
+++ b/src/test/java/org/tikv/raw/RawKVClientTest.java
@@ -361,7 +361,7 @@ public class RawKVClientTest extends BaseRawKVTest {
     }
 
     int i = 0;
-    Iterator<KvPair> iter = client.scan0(prefix, ByteString.EMPTY, cnt);
+    Iterator<KvPair> iter = client.scanPrefix0(prefix, cnt, false);
     while (iter.hasNext()) {
       i++;
       KvPair pair = iter.next();
@@ -370,7 +370,7 @@ public class RawKVClientTest extends BaseRawKVTest {
     assertEquals(cnt, i);
 
     i = 0;
-    iter = client.scan0(prefix, ByteString.EMPTY, true);
+    iter = client.scanPrefix0(prefix, true);
     while (iter.hasNext()) {
       i++;
       KvPair pair = iter.next();
@@ -398,7 +398,7 @@ public class RawKVClientTest extends BaseRawKVTest {
         });
     client.ingest(kvs);
 
-    assertEquals(client.scan(prefix, ByteString.EMPTY).size(), cnt);
+    assertEquals(client.scanPrefix(prefix).size(), cnt);
   }
 
   @Test

--- a/src/test/java/org/tikv/raw/RawKVClientTest.java
+++ b/src/test/java/org/tikv/raw/RawKVClientTest.java
@@ -1084,4 +1084,20 @@ public class RawKVClientTest extends BaseRawKVTest {
       return FastByteComparisons.compareTo(startKey.toByteArray(), endKey.toByteArray());
     }
   }
+
+  @Test
+  public void testBatchPut() throws Exception {
+    TiConfiguration conf = session.getConf();
+    conf.setRawKVBatchWriteTimeoutInMS(100000);
+    conf.setTimeout(100000);
+    try(TiSession newSession = TiSession.create(conf)){
+      try(RawKVClient client=newSession.createRawClient()) {
+        HashMap<ByteString, ByteString> kvs = new HashMap<>();
+        for (int i = 0; i < 2048; i++) {
+          kvs.put(ByteString.copyFromUtf8("key@" + i), rawValue("value@" + i));
+        }
+        client.batchPut(kvs);
+      }
+    };
+  }
 }


### PR DESCRIPTION
Signed-off-by: iosmanthus <myosmanthustree@gmail.com>

### What problem does this PR solve?

Issue Number: close #634

Problem Description:

The following code will hang in the master:

```java
HashMap<ByteString, ByteString> kvs = new HashMap<>();
for (int i = 0; i < MAX_RAW_BATCH_LIMIT * 4; i++) {
  kvs.put(prefix.concat(ByteString.copyFromUtf8("key@" + i)), rawValue("value@" + i));
}
client.batchPut(kvs);
```

### What is changed and how does it work?

The code is dislocation while cherry picks other commits from release-3.1


### Check List for Tests

This PR has been tested by at least one of the following methods:
- Unit test
- Integration test

### Related changes

<!-- REMOVE the items that are not applicable -->
- Need to cherry-pick the release branch
