### PR TITLE
add time unit for ttl param

### DIFF
--- a/src/test/java/org/tikv/raw/CASTest.java
+++ b/src/test/java/org/tikv/raw/CASTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertFalse;
 
 import com.google.protobuf.ByteString;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -34,6 +35,7 @@ import org.tikv.common.TiSession;
 import org.tikv.common.exception.RawCASConflictException;
 
 public class CASTest extends BaseRawKVTest {
+
   private RawKVClient client;
   private boolean initialized;
   private static final Logger logger = LoggerFactory.getLogger(RawKVClientTest.class);
@@ -81,21 +83,22 @@ public class CASTest extends BaseRawKVTest {
 
   @Test
   public void rawPutIfAbsentTest() {
-    long ttl = 10;
+    long duration = 10;
+    TimeUnit timeUnit = TimeUnit.SECONDS;
     ByteString key = ByteString.copyFromUtf8("key_atomic");
     ByteString value = ByteString.copyFromUtf8("value");
     ByteString value2 = ByteString.copyFromUtf8("value2");
     client.delete(key);
-    Optional<ByteString> res1 = client.putIfAbsent(key, value, ttl);
+    Optional<ByteString> res1 = client.putIfAbsent(key, value, duration, timeUnit);
     assertFalse(res1.isPresent());
-    Optional<ByteString> res2 = client.putIfAbsent(key, value2, ttl);
+    Optional<ByteString> res2 = client.putIfAbsent(key, value2, duration, timeUnit);
     assertEquals(res2.get(), value);
     try {
-      Thread.sleep(ttl * 1000 + 100);
+      Thread.sleep(duration * 1000 + 100);
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
     }
-    Optional<ByteString> res3 = client.putIfAbsent(key, value, ttl);
+    Optional<ByteString> res3 = client.putIfAbsent(key, value, duration, timeUnit);
     assertFalse(res3.isPresent());
   }
 }

--- a/src/test/java/org/tikv/raw/RawKVClientTest.java
+++ b/src/test/java/org/tikv/raw/RawKVClientTest.java
@@ -68,6 +68,7 @@ import org.tikv.kvproto.Kvrpcpb;
 import org.tikv.kvproto.Kvrpcpb.KvPair;
 
 public class RawKVClientTest extends BaseRawKVTest {
+
   private static final String RAW_PREFIX = "raw_\u0001_";
   private static final int KEY_POOL_SIZE = 1000000;
   private static final int TEST_CASES = 10000;
@@ -143,7 +144,7 @@ public class RawKVClientTest extends BaseRawKVTest {
     long ttl = 10;
     ByteString key = ByteString.copyFromUtf8("key_ttl");
     ByteString value = ByteString.copyFromUtf8("value");
-    client.put(key, value, ttl);
+    client.put(key, value, ttl, TimeUnit.SECONDS);
     for (int i = 0; i < 9; i++) {
       Optional<Long> t = client.getKeyTTL(key);
       logger.info("current ttl of key is " + t.orElse(null));


### PR DESCRIPTION
<!-- Thank you for contributing to TiKV Java Client!

PR Title Format: "[close/to/fix #issue_number] summary" -->

### What problem does this PR solve?
add methods with time unit param for `RawKVClientBase` for easier use 

### What is changed and how does it work?
add default method in interface `RawKVClientBase`include 
- `  void put(ByteString key, ByteString value, long ttl)`
-  `  Optional<ByteString> putIfAbsent(ByteString key, ByteString value, long ttl)`
-  `void compareAndSet(ByteString key, Optional<ByteString> prevValue, ByteString value, long ttl)`
- `  void batchPut(Map<ByteString, ByteString> kvPairs, long ttl);`

### Code changes

<!-- REMOVE the items that are not applicable -->
- Has methods of interface change YES

### Check List for Tests

This PR has been tested by at least one of the following methods:
- Unit test

### Side effects

<!-- REMOVE the items that are not applicable -->
- No side effects

### Related changes

<!-- REMOVE the items that are not applicable -->
- Need to update the documentation
- Need to be included in the release note