### PR TITLE
change method name StoreVersion.minTiKVVersion  to  StoreVersion.isTi…

### DIFF
--- a/src/main/java/org/tikv/common/StoreVersion.java
+++ b/src/main/java/org/tikv/common/StoreVersion.java
@@ -58,7 +58,7 @@ public class StoreVersion {
     return new StoreVersion(v0).toIntVersion() - new StoreVersion(v1).toIntVersion();
   }
 
-  public static boolean minTiKVVersion(String version, PDClient pdClient) {
+  public static boolean isTiKVVersionGreatEqualThanVersion(PDClient pdClient, String version) {
     StoreVersion storeVersion = new StoreVersion(version);
 
     BackOffer bo =

--- a/src/main/java/org/tikv/common/TiSession.java
+++ b/src/main/java/org/tikv/common/TiSession.java
@@ -175,7 +175,8 @@ public class TiSession implements AutoCloseable {
     }
 
     this.client = PDClient.createRaw(conf, keyCodec, channelFactory);
-    if (conf.getApiVersion().isV2() && !StoreVersion.minTiKVVersion(Version.API_V2, client)) {
+    if (conf.getApiVersion().isV2()
+        && !StoreVersion.isTiKVVersionGreatEqualThanVersion(client, Version.API_V2)) {
       throw new IllegalStateException(
           "With API v2, store versions should not older than " + Version.API_V2);
     }

--- a/src/main/java/org/tikv/common/region/RegionStoreClient.java
+++ b/src/main/java/org/tikv/common/region/RegionStoreClient.java
@@ -145,7 +145,7 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
 
   private synchronized Boolean getIsV4() {
     if (isV4 == null) {
-      isV4 = StoreVersion.minTiKVVersion(Version.RESOLVE_LOCK_V4, pdClient);
+      isV4 = StoreVersion.isTiKVVersionGreatEqualThanVersion(pdClient, Version.RESOLVE_LOCK_V4);
     }
     return isV4;
   }

--- a/src/test/java/org/tikv/BaseRawKVTest.java
+++ b/src/test/java/org/tikv/BaseRawKVTest.java
@@ -29,7 +29,7 @@ public class BaseRawKVTest {
     TiConfiguration conf = createTiConfiguration();
     TiSession session = TiSession.create(conf);
     PDClient pdClient = session.getPDClient();
-    return StoreVersion.minTiKVVersion(expectedVersion, pdClient);
+    return StoreVersion.isTiKVVersionGreatEqualThanVersion(pdClient, expectedVersion);
   }
 
   protected TiConfiguration createTiConfiguration() {

--- a/src/test/java/org/tikv/common/ApiVersionTest.java
+++ b/src/test/java/org/tikv/common/ApiVersionTest.java
@@ -55,8 +55,8 @@ public class ApiVersionTest {
   }
 
   private boolean minTiKVVersion(String version) {
-    return StoreVersion.minTiKVVersion(
-        version, TiSession.create(createConfiguration()).getPDClient());
+    return StoreVersion.isTiKVVersionGreatEqualThanVersion(
+        TiSession.create(createConfiguration()).getPDClient(), version);
   }
 
   @Test


### PR DESCRIPTION
### What problem does this PR solve?

Problem Description: 
The name of the current `minTiKVVersion` method is confusing, TiSpark changed the method name to `isTiKVVersionGreatEqualThanVersion` in [#2481](https://github.com/pingcap/tispark/pull/2481). Currently, tiSpark is trying to refactor the client using client-java, hopefully, client-java can modify this error-prone method name.