### PR TITLE
[close #657] add production-readiness document

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -4,6 +4,8 @@
 
 - [Introduction](./introduction/introduction.md)
 
+- [Production Readiness](./production-readiness.md)
+
 - [Start With Examples](./examples/introduction.md)
     - [Quick Start](./examples/quick-start.md)
     - [Interact with TiKV RawKV API](./examples/rawkv.md)

--- a/docs/src/production-readiness.md
+++ b/docs/src/production-readiness.md
@@ -10,7 +10,7 @@ At the same time, RawKV has been used in the production environment of some comm
 ## TxnKV
 All TxnKV APIs are covered by [CI](https://github.com/tikv/client-java/actions/workflows/ci.yml).
 
-In the meantime, TxnKV has been used in the [TiBigData](https://github.com/tidb-incubator/TiBigData) project to integrate data from TiDB to ODS for building data warehouses. And TiBigData was used in the production system of a couple of internet companies.
+In the meantime, TxnKV has been used in the [TiSpark](https://docs.pingcap.com/tidb/stable/tispark-overview) and [TiBigData](https://github.com/tidb-incubator/TiBigData) project to integrate data from TiDB to Big Data ecosystem. TiSpark or TiBigData were used in the production system of couple of commercial customers and some internet companies.
 
 Similar to RawKV, only part of APIs are used in this scenario (mainly including `prewrite/commit` and `coprocessor`). And this use case doesn't care about latency but throughput and reliability.
 

--- a/docs/src/production-readiness.md
+++ b/docs/src/production-readiness.md
@@ -1,16 +1,16 @@
 # Production Readiness
 
-In general, latest [release](https://github.com/tikv/client-java/releases) of TiKV Java Client is ready for production use. But it is not battle-tested as full featured client for TiKV in production environment. This page will give you more detail.
+In general, the latest [release](https://github.com/tikv/client-java/releases) of TiKV Java Client is ready for production use. But it is not battle-tested as full featured client for TiKV in all use cases. This page will give you more details.
 
 ## RawKV
 All RawKV APIs are covered by [CI](https://github.com/tikv/client-java/actions/workflows/ci.yml).
 
-At the same time, RawKV has been used in the production environment of some commercial users in latency sensitive systems. But they only use part of the RawKV APIs (mainly including `raw_put`, `raw_get`, `raw_compare_and_swap`, and `raw_batch_put`).
+At this time, RawKV has been used in the production environment of some commercial customers in latency sensitive systems. But they only use part of the RawKV APIs (mainly including `raw_put`, `raw_get`, `raw_compare_and_swap`, and `raw_batch_put`).
 
 ## TxnKV
 All TxnKV APIs are covered by [CI](https://github.com/tikv/client-java/actions/workflows/ci.yml).
 
-In the meantime, TxnKV has been used in the [TiSpark](https://docs.pingcap.com/tidb/stable/tispark-overview) and [TiBigData](https://github.com/tidb-incubator/TiBigData) project to integrate data from TiDB to Big Data ecosystem. TiSpark or TiBigData were used in the production system of couple of commercial customers and some internet companies.
+In addition, TxnKV has been used in the [TiSpark](https://docs.pingcap.com/tidb/stable/tispark-overview) and [TiBigData](https://github.com/tidb-incubator/TiBigData) project to integrate data from TiDB to Big Data ecosystem. TiSpark and TiBigData were used in the production system of some commercial customers and some internet companies.
 
 Similar to RawKV, only part of APIs are used in this scenario (mainly including `prewrite/commit` and `coprocessor`). And this use case doesn't care about latency but throughput and reliability.
 

--- a/docs/src/production-readiness.md
+++ b/docs/src/production-readiness.md
@@ -10,7 +10,7 @@ At this time, RawKV has been used in the production environment of some commerci
 ## TxnKV
 All TxnKV APIs are covered by [CI](https://github.com/tikv/client-java/actions/workflows/ci.yml).
 
-In addition, TxnKV has been used in the [TiSpark](https://docs.pingcap.com/tidb/stable/tispark-overview) and [TiBigData](https://github.com/tidb-incubator/TiBigData) project to integrate data from TiDB to Big Data ecosystem. TiSpark and TiBigData were used in the production system of some commercial customers and some internet companies.
+In addition, TxnKV has been used in the [TiSpark](https://docs.pingcap.com/tidb/stable/tispark-overview) and [TiBigData](https://github.com/tidb-incubator/TiBigData) project to integrate data from TiDB to Big Data ecosystem. TiSpark and TiBigData are used in the production system of some commercial customers and internet companies.
 
 Similar to RawKV, only part of APIs are used in this scenario (mainly including `prewrite/commit` and `coprocessor`). And this use case doesn't care about latency but throughput and reliability.
 

--- a/docs/src/production-readiness.md
+++ b/docs/src/production-readiness.md
@@ -1,0 +1,18 @@
+# Production Readiness
+
+In general, latest [release](https://github.com/tikv/client-java/releases) of TiKV Java Client is ready for production use. But it is not battle-tested as full featured client for TiKV in production environment. This page will give you more detail.
+
+## RawKV
+All RawKV APIs are covered by [CI](https://github.com/tikv/client-java/actions/workflows/ci.yml).
+
+At the same time, RawKV has been used in the production environment of some commercial users in latency sensitive systems. But they only use part of the RawKV APIs (mainly including `raw_put`, `raw_get`, `raw_compare_and_swap`, and `raw_batch_put`).
+
+## TxnKV
+All TxnKV APIs are covered by [CI](https://github.com/tikv/client-java/actions/workflows/ci.yml).
+
+In the meantime, TxnKV has been used in the [TiBigData](https://github.com/tidb-incubator/TiBigData) project to integrate data from TiDB to ODS for building data warehouses. And TiBigData was used in the production system of a couple of internet companies.
+
+Similar to RawKV, only part of APIs are used in this scenario (mainly including `prewrite/commit` and `coprocessor`). And this use case doesn't care about latency but throughput and reliability.
+
+## TiDB Cloud
+Directly using TiKV is not possible on TiDB Cloud due to the fact that client has to access the whole cluster, which has security issues. And TiKV managed service is not coming soon as it's not contained in [roadmap](https://docs.pingcap.com/tidbcloud/tidb-cloud-roadmap) yet.


### PR DESCRIPTION
Signed-off-by: pingyu <yuping@pingcap.com>

<!-- Thank you for contributing to TiKV Java Client!

PR Title Format: "[close/to/fix #issue_number] summary" -->

### What problem does this PR solve?

Issue Number: close #657 

Problem Description: Add documents for production ready status of Java Client, to help users make decision about whether to use Java Client.

### What is changed and how does it work?

Add `production-readiness.md` and add link to index.

See [rendered](https://github.com/pingyu/client-java/blob/doc-production-readiness/docs/src/production-readiness.md).

### Code changes

<!-- REMOVE the items that are not applicable -->
- No code

### Check List for Tests

This PR has been tested by at least one of the following methods:
- No code

### Side effects

<!-- REMOVE the items that are not applicable -->
- NO side effects

### Related changes

<!-- REMOVE the items that are not applicable -->
- NO related changes
