### PR TITLE
[close #663] Select TiFlash Stores Round-Robin

### DIFF
--- a/.github/workflows/license-checker.yml
+++ b/.github/workflows/license-checker.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Check License Header
-        uses: apache/skywalking-eyes@main
+        uses: apache/skywalking-eyes@v0.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/src/main/java/org/tikv/common/ConfigUtils.java
+++ b/src/main/java/org/tikv/common/ConfigUtils.java
@@ -121,6 +121,7 @@ public class ConfigUtils {
 
   public static final String TIFLASH_ENABLE = "tiflash.enable";
   public static final String TIKV_WARM_UP_ENABLE = "tikv.warm_up.enable";
+  public static final String TIFLASH_BALANCE_STRATEGY = "tiflash.balance_strategy";
 
   public static final String TIKV_API_VERSION = "tikv.api_version";
 

--- a/src/main/java/org/tikv/common/ConfigUtils.java
+++ b/src/main/java/org/tikv/common/ConfigUtils.java
@@ -121,7 +121,6 @@ public class ConfigUtils {
 
   public static final String TIFLASH_ENABLE = "tiflash.enable";
   public static final String TIKV_WARM_UP_ENABLE = "tikv.warm_up.enable";
-  public static final String TIFLASH_BALANCE_STRATEGY = "tiflash.balance_strategy";
 
   public static final String TIKV_API_VERSION = "tikv.api_version";
 

--- a/src/main/java/org/tikv/common/region/RegionManager.java
+++ b/src/main/java/org/tikv/common/region/RegionManager.java
@@ -42,7 +42,6 @@ import org.tikv.common.util.HistogramUtils;
 import org.tikv.common.util.Pair;
 import org.tikv.kvproto.Metapb;
 import org.tikv.kvproto.Metapb.Peer;
-import org.tikv.kvproto.Metapb.Store;
 import org.tikv.kvproto.Metapb.StoreState;
 import org.tikv.kvproto.Pdpb;
 

--- a/src/main/java/org/tikv/common/region/RegionManager.java
+++ b/src/main/java/org/tikv/common/region/RegionManager.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.tikv.common.ReadOnlyPDClient;
@@ -68,7 +69,7 @@ public class RegionManager {
   private final TiConfiguration conf;
   private final ScheduledExecutorService executor;
   private final StoreHealthyChecker storeChecker;
-  private int TiFlashStoreIndex = 0;
+  private AtomicInteger tiflashStoreIndex = new AtomicInteger(0);
 
   public RegionManager(
       TiConfiguration conf, ReadOnlyPDClient pdClient, ChannelFactory channelFactory) {
@@ -204,9 +205,7 @@ public class RegionManager {
       }
       // select a tiflash with RR strategy
       if (tiflashStores.size() > 0) {
-        store =
-            tiflashStores.get(TiFlashStoreIndex > tiflashStores.size() - 1 ? 0 : TiFlashStoreIndex);
-        TiFlashStoreIndex++;
+        store = tiflashStores.get(tiflashStoreIndex.getAndIncrement() % tiflashStores.size());
       }
 
       if (store == null) {

--- a/src/main/java/org/tikv/common/region/RegionManager.java
+++ b/src/main/java/org/tikv/common/region/RegionManager.java
@@ -23,7 +23,6 @@ import com.google.protobuf.ByteString;
 import io.prometheus.client.Histogram;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -69,6 +68,7 @@ public class RegionManager {
   private final TiConfiguration conf;
   private final ScheduledExecutorService executor;
   private final StoreHealthyChecker storeChecker;
+  private int TiFlashStoreIndex = 0;
 
   public RegionManager(
       TiConfiguration conf, ReadOnlyPDClient pdClient, ChannelFactory channelFactory) {
@@ -202,9 +202,11 @@ public class RegionManager {
           }
         }
       }
-      // select a tiflash randomly
-      if(tiflashStores.size() > 0) {
-        store = tiflashStores.get(new Random().nextInt(tiflashStores.size()));
+      // select a tiflash with RR strategy
+      if (tiflashStores.size() > 0) {
+        store =
+            tiflashStores.get(TiFlashStoreIndex > tiflashStores.size() - 1 ? 0 : TiFlashStoreIndex);
+        TiFlashStoreIndex++;
       }
 
       if (store == null) {

--- a/src/main/java/org/tikv/common/region/RegionManager.java
+++ b/src/main/java/org/tikv/common/region/RegionManager.java
@@ -204,9 +204,9 @@ public class RegionManager {
         }
       }
       // select a tiflash randomly
-      Random random = new Random();
-      int randomIndex = random.nextInt(tiflashStores.size());
-      store = tiflashStores.get(randomIndex);
+      if(tiflashStores.size() > 0) {
+        store = tiflashStores.get(new Random().nextInt(tiflashStores.size()));
+      }
 
       if (store == null) {
         // clear the region cache, so we may get the learner peer next time

--- a/src/test/java/org/tikv/common/GrpcUtils.java
+++ b/src/test/java/org/tikv/common/GrpcUtils.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import org.tikv.common.codec.Codec.BytesCodec;
 import org.tikv.common.codec.CodecDataOutput;
 import org.tikv.kvproto.Metapb.Peer;
+import org.tikv.kvproto.Metapb.PeerRole;
 import org.tikv.kvproto.Metapb.Region;
 import org.tikv.kvproto.Metapb.RegionEpoch;
 import org.tikv.kvproto.Metapb.Store;
@@ -59,6 +60,10 @@ public class GrpcUtils {
 
   public static Peer makePeer(long id, long storeId) {
     return Peer.newBuilder().setStoreId(storeId).setId(id).build();
+  }
+
+  public static Peer makeLearnerPeer(long id, long storeId) {
+    return Peer.newBuilder().setRole(PeerRole.Learner).setStoreId(storeId).setId(id).build();
   }
 
   public static ByteString encodeKey(byte[] key) {


### PR DESCRIPTION
<!-- Thank you for contributing to TiKV Java Client!

PR Title Format: "[close/to/fix #issue_number] summary" -->

### What problem does this PR solve?


Problem Description: **client-java always selects the first TiFlash store which may cause read hotspot.**

### What is changed and how does it work?

Choose the TiFlash stores Round-Robin

### Code changes

<!-- REMOVE the items that are not applicable -->
- Has exported function/method change
- Has exported variable/fields change
- Has methods of interface change
- Has persistent data change
- No code

### Check List for Tests

This PR has been tested by at least one of the following methods:
- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

### Side effects

<!-- REMOVE the items that are not applicable -->
- Possible performance regression, WHY: **TBD**
- Increased code complexity, WHY: **TBD**
- Breaking backward compatibility, WHY: **TBD**
- NO side effects

### Related changes

<!-- REMOVE the items that are not applicable -->
- Need to cherry-pick to the release branch
- Need to update the documentation
- Need to be included in the release note
- NO related changes
