### PR TITLE
fix by upgrade protobuf version so that it will build on M1 Macs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <protobuf.version>3.5.1</protobuf.version>
+        <protobuf.version>3.18.0</protobuf.version>
         <log4j.version>1.2.17</log4j.version>
         <slf4j.version>1.7.16</slf4j.version>
         <grpc.version>1.48.0</grpc.version>


### PR DESCRIPTION
Currently the client won't build on M1 Macs, because the protoc binary for aarch64 is missing.
Upgrade the protobuf dependency solves the problem.