### PR TITLE
fix byte array overflow

### DIFF
--- a/src/main/java/org/tikv/common/codec/RowV2.java
+++ b/src/main/java/org/tikv/common/codec/RowV2.java
@@ -147,7 +147,7 @@ public class RowV2 {
       if (this.large) {
         v = this.colIDs32[h];
       } else {
-        v = this.colIDs[h];
+        v = this.colIDs[h] & 0xFF;
       }
       if (v < colID) {
         i = h + 1;


### PR DESCRIPTION
<!-- Thank you for contributing to TiKV Java Client!
PR Title Format: "[close/to/fix #issue_number] summary" -->

fix byte array overflow when column id greater than 128

### What problem does this PR solve?
 when use tidb-cdc in flink,if table column size greater than 128 fields,the left field value cant't be read,and is null value,after review related code,i found a bug, when column id greater than 128,colIds is overflow,so binary search can't find correct column id in colIDs array

the detail bug description
https://github.com/ververica/flink-cdc-connectors/issues/1883

