### PR TITLE
[close #736] Select reachable store

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.tikv</groupId>
     <artifactId>tikv-client-java</artifactId>
-    <version>3.3.0-SNAPSHOT</version>
+    <version>3.3.4-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>TiKV Java Client</name>
     <description>A Java Client for TiKV</description>

--- a/src/main/java/org/tikv/common/region/RegionManager.java
+++ b/src/main/java/org/tikv/common/region/RegionManager.java
@@ -232,6 +232,7 @@ public class RegionManager {
       Peer peer = region.getCurrentReplica();
       store = getStoreById(peer.getStoreId(), backOffer);
       while (!store.isReachable()) {
+        logger.info("Store is unreachable, try to get the next replica");
         peer = region.getNextReplica();
         store = getStoreById(peer.getStoreId(), backOffer);
       }

--- a/src/main/java/org/tikv/common/region/RegionManager.java
+++ b/src/main/java/org/tikv/common/region/RegionManager.java
@@ -229,15 +229,16 @@ public class RegionManager {
     TiStore store = null;
     if (storeType == TiStoreType.TiKV) {
       // check from the first replica in case it recovers
-      for (int i = 0; i < region.getReplicaList().size(); i++) {
-        Peer peer = region.getReplicaList().get(i);
+      List<Peer> replicaList = region.getReplicaList();
+      for (int i = 0; i < replicaList.size(); i++) {
+        Peer peer = replicaList.get(i);
         store = getStoreById(peer.getStoreId(), backOffer);
         if (store.isReachable()) {
           // update replica index
           region.setReplicaIdx(i);
           break;
         }
-        logger.info("Store is unreachable, try to get the replica,index: " + i);
+        logger.info("Store {} is unreachable, try to get the next replica", peer.getStoreId());
       }
     } else {
       List<TiStore> tiflashStores = new ArrayList<>();

--- a/src/main/java/org/tikv/common/region/RegionManager.java
+++ b/src/main/java/org/tikv/common/region/RegionManager.java
@@ -234,7 +234,7 @@ public class RegionManager {
         Peer peer = replicaList.get(i);
         store = getStoreById(peer.getStoreId(), backOffer);
         if (store.isReachable()) {
-          // update replica index
+          // update replica's index
           region.setReplicaIdx(i);
           break;
         }

--- a/src/main/java/org/tikv/common/region/RegionManager.java
+++ b/src/main/java/org/tikv/common/region/RegionManager.java
@@ -231,7 +231,7 @@ public class RegionManager {
       region.SetReplicaIdx(0);
       Peer peer = region.getCurrentReplica();
       store = getStoreById(peer.getStoreId(), backOffer);
-      while (!store.isReachable()){
+      while (!store.isReachable()) {
         peer = region.getNextReplica();
         store = getStoreById(peer.getStoreId(), backOffer);
       }

--- a/src/main/java/org/tikv/common/region/TiRegion.java
+++ b/src/main/java/org/tikv/common/region/TiRegion.java
@@ -126,6 +126,10 @@ public class TiRegion implements Serializable {
     return getCurrentReplica();
   }
 
+  public void SetReplicaIdx(int idx) {
+    replicaIdx = idx;
+  }
+
   private boolean isLeader(Peer peer) {
     return getLeader().equals(peer);
   }

--- a/src/main/java/org/tikv/common/region/TiRegion.java
+++ b/src/main/java/org/tikv/common/region/TiRegion.java
@@ -126,8 +126,12 @@ public class TiRegion implements Serializable {
     return getCurrentReplica();
   }
 
-  public void SetReplicaIdx(int idx) {
+  public void setReplicaIdx(int idx) {
     replicaIdx = idx;
+  }
+
+  public List<Peer> getReplicaList() {
+    return replicaList;
   }
 
   private boolean isLeader(Peer peer) {


### PR DESCRIPTION
<!-- Thank you for contributing to TiKV Java Client!

PR Title Format: "[close/to/fix #issue_number] summary" -->

### What problem does this PR solve?

Issue Number: close #736

### What is changed and how does it work?

Judge store status before use. Use the next replica when the current replica is unreachable.

### Test

I have tested in TiSpark follower read with the first store killed, its success to request the next store.


