### PR TITLE
discard the extended checksum part in row values

### DIFF
--- a/src/main/java/org/tikv/common/codec/RowV2.java
+++ b/src/main/java/org/tikv/common/codec/RowV2.java
@@ -78,6 +78,7 @@ public class RowV2 {
     this.numNotNullCols = cdi.readUnsignedShort();
     this.numNullCols = cdi.readUnsignedShort();
     int cursor = 6;
+    int dataLen = 0;
     if (this.large) {
       int numCols = this.numNotNullCols + this.numNullCols;
       int colIDsLen = numCols * 4;
@@ -93,6 +94,9 @@ public class RowV2 {
         this.offsets32[i] = cdi.readInt();
       }
       cursor += offsetsLen;
+      if (numCols > 0) {
+        dataLen = this.offsets[numCols - 1];
+      }
     } else {
       int numCols = this.numNotNullCols + this.numNullCols;
       int colIDsLen = numCols;
@@ -106,8 +110,11 @@ public class RowV2 {
         this.offsets[i] = cdi.readUnsignedShort();
       }
       cursor += offsetsLen;
+      if (numCols > 0) {
+        dataLen = this.offsets[numCols - 1];
+      }
     }
-    this.data = Arrays.copyOfRange(rowData, cursor, rowData.length);
+    this.data = Arrays.copyOfRange(rowData, cursor, cursor + dataLen);
   }
 
   private void writeShortArray(CodecDataOutput cdo, int[] arr) {


### PR DESCRIPTION
<!-- Thank you for contributing to TiKV Java Client!

PR Title Format: "[close/to/fix #issue_number] summary" -->

### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tidb/issues/42747

Problem Description:

Row values now may have extended checksums since [pingcap/tidb#42859](https://github.com/pingcap/tidb/pull/42859/files#diff-204c31e3bed4805eefcfff1f62863268dfbedb8b81d066223fe4e58ef6527ddaR46), so client-java need to discard these checksums on read.

### What is changed and how does it work?

Do not copy the checksum part to `RowV2.data`. Actually the current implementation is ok since `RowV2.data` can be only accessed by `RowV2.getData`. This PR just makes it more safer.
