### PR TITLE
[close #749] Fix health checking issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.tikv</groupId>
     <artifactId>tikv-client-java</artifactId>
-    <version>3.3.4-SNAPSHOT</version>
+    <version>3.3.4-health</version>
     <packaging>jar</packaging>
     <name>TiKV Java Client</name>
     <description>A Java Client for TiKV</description>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.tikv</groupId>
     <artifactId>tikv-client-java</artifactId>
-    <version>3.3.4-health</version>
+    <version>3.3.4-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>TiKV Java Client</name>
     <description>A Java Client for TiKV</description>

--- a/src/main/java/org/tikv/common/region/RegionManager.java
+++ b/src/main/java/org/tikv/common/region/RegionManager.java
@@ -235,10 +235,12 @@ public class RegionManager {
         store = getStoreById(peer.getStoreId(), backOffer);
         if (store.isReachable()) {
           // update replica's index
+          logger.info("Store {} is reachable, use it as store", peer.getStoreId());
           region.setReplicaIdx(i);
           break;
         }
         logger.info("Store {} is unreachable, try to get the next replica", peer.getStoreId());
+        store = null;
       }
     } else {
       List<TiStore> tiflashStores = new ArrayList<>();

--- a/src/main/java/org/tikv/common/region/RegionManager.java
+++ b/src/main/java/org/tikv/common/region/RegionManager.java
@@ -235,12 +235,10 @@ public class RegionManager {
         store = getStoreById(peer.getStoreId(), backOffer);
         if (store.isReachable()) {
           // update replica's index
-          logger.info("Store {} is reachable, use it as store", peer.getStoreId());
           region.setReplicaIdx(i);
           break;
         }
         logger.info("Store {} is unreachable, try to get the next replica", peer.getStoreId());
-        store = null;
       }
     } else {
       List<TiStore> tiflashStores = new ArrayList<>();
@@ -249,11 +247,8 @@ public class RegionManager {
         if (!s.isReachable()) {
           continue;
         }
-        for (Metapb.StoreLabel label : s.getStore().getLabelsList()) {
-          if (label.getKey().equals(storeType.getLabelKey())
-              && label.getValue().equals(storeType.getLabelValue())) {
-            tiflashStores.add(s);
-          }
+        if (s.isTiFlash()) {
+          tiflashStores.add(s);
         }
       }
       // select a tiflash with Round-Robin strategy

--- a/src/main/java/org/tikv/common/region/StoreHealthyChecker.java
+++ b/src/main/java/org/tikv/common/region/StoreHealthyChecker.java
@@ -100,7 +100,8 @@ public class StoreHealthyChecker implements Runnable {
               stub.getChannel(), TikvGrpc.getIsAliveMethod(), stub.getCallOptions(), factory.get());
       return resp != null && resp.getAvailable();
     } catch (Exception e) {
-      logger.warn("fail to check TiFlash health, regrade as unhealthy. TiFlash address: " + addressStr, e);
+      logger.warn(
+          "fail to check TiFlash health, regrade as unhealthy. TiFlash address: " + addressStr, e);
       return false;
     }
   }
@@ -114,7 +115,8 @@ public class StoreHealthyChecker implements Runnable {
       HealthCheckResponse resp = stub.check(req);
       return resp.getStatus() == HealthCheckResponse.ServingStatus.SERVING;
     } catch (Exception e) {
-      logger.warn("fail to check TiKV health, regrade as unhealthy. TiKV address: " + addressStr, e);
+      logger.warn(
+          "fail to check TiKV health, regrade as unhealthy. TiKV address: " + addressStr, e);
       return false;
     }
   }

--- a/src/main/java/org/tikv/common/region/StoreHealthyChecker.java
+++ b/src/main/java/org/tikv/common/region/StoreHealthyChecker.java
@@ -100,7 +100,7 @@ public class StoreHealthyChecker implements Runnable {
               stub.getChannel(), TikvGrpc.getIsAliveMethod(), stub.getCallOptions(), factory.get());
       return resp != null && resp.getAvailable();
     } catch (Exception e) {
-      logger.warn("fail to check TiFlash health, regrade as unhealthy", e);
+      logger.warn("fail to check TiFlash health, regrade as unhealthy. TiFlash address: " + addressStr, e);
       return false;
     }
   }
@@ -114,7 +114,7 @@ public class StoreHealthyChecker implements Runnable {
       HealthCheckResponse resp = stub.check(req);
       return resp.getStatus() == HealthCheckResponse.ServingStatus.SERVING;
     } catch (Exception e) {
-      logger.warn("fail to check TiKV health, regrade as unhealthy", e);
+      logger.warn("fail to check TiKV health, regrade as unhealthy. TiKV address: " + addressStr, e);
       return false;
     }
   }

--- a/src/main/java/org/tikv/common/region/StoreHealthyChecker.java
+++ b/src/main/java/org/tikv/common/region/StoreHealthyChecker.java
@@ -80,11 +80,8 @@ public class StoreHealthyChecker implements Runnable {
 
   private boolean checkStoreHealth(TiStore store) {
     String addressStr = store.getStore().getAddress();
-    for (Metapb.StoreLabel label : store.getStore().getLabelsList()) {
-      if (label.getKey().equals(TiStoreType.TiFlash.getLabelKey())
-          && label.getValue().equals(TiStoreType.TiFlash.getLabelValue())) {
-        return checkTiFlashHealth(addressStr);
-      }
+    if (store.isTiFlash()) {
+      return checkTiFlashHealth(addressStr);
     }
     return checkTiKVHealth(addressStr);
   }
@@ -100,8 +97,8 @@ public class StoreHealthyChecker implements Runnable {
               stub.getChannel(), TikvGrpc.getIsAliveMethod(), stub.getCallOptions(), factory.get());
       return resp != null && resp.getAvailable();
     } catch (Exception e) {
-      logger.warn(
-          "fail to check TiFlash health, regrade as unhealthy. TiFlash address: " + addressStr, e);
+      logger.info(
+          "fail to check TiFlash health, regard as unhealthy. TiFlash address: " + addressStr, e);
       return false;
     }
   }
@@ -115,8 +112,7 @@ public class StoreHealthyChecker implements Runnable {
       HealthCheckResponse resp = stub.check(req);
       return resp.getStatus() == HealthCheckResponse.ServingStatus.SERVING;
     } catch (Exception e) {
-      logger.warn(
-          "fail to check TiKV health, regrade as unhealthy. TiKV address: " + addressStr, e);
+      logger.info("fail to check TiKV health, regard as unhealthy. TiKV address: " + addressStr, e);
       return false;
     }
   }

--- a/src/main/java/org/tikv/common/region/TiStore.java
+++ b/src/main/java/org/tikv/common/region/TiStore.java
@@ -105,4 +105,14 @@ public class TiStore implements Serializable {
   public long getId() {
     return this.store.getId();
   }
+
+  public boolean isTiFlash() {
+    for (Metapb.StoreLabel label : store.getLabelsList()) {
+      if (label.getKey().equals(TiStoreType.TiFlash.getLabelKey())
+          && label.getValue().equals(TiStoreType.TiFlash.getLabelValue())) {
+        return true;
+      }
+    }
+    return false;
+  }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to TiKV Java Client!

PR Title Format: "[close/to/fix #issue_number] summary" -->

### What problem does this PR solve?

Issue Number: close #749

https://github.com/pingcap/tispark/issues/2707

Problem Description: StoreHealthyChecker fails to check the status of TiFlash

### What is changed and how does it work?

Use isMppalive RPC to probe the status of TiFlash.

### Check List for Tests

Manual test：

I have tested this locally with TiSpark. TiSpark will request TiFlash using client-java

1. TiSpark will with the client-java before  this PR will throw errors even if TiFlash is alive

```
23/05/20 15:31:12 WARN StoreHealthyChecker: fail to check TiFlash health, regrade as unhealthy
org.tikv.shade.io.grpc.StatusRuntimeException: DEADLINE_EXCEEDED: deadline exceeded after 1.999882667s. [closed=[], open=[[buffered_nanos=2005712916, waiting_for_connection]]]
	at org.tikv.shade.io.grpc.stub.ClientCalls.toStatusRuntimeException(ClientCalls.java:287)
	at org.tikv.shade.io.grpc.stub.ClientCalls.getUnchecked(ClientCalls.java:268)
	at org.tikv.shade.io.grpc.stub.ClientCalls.blockingUnaryCall(ClientCalls.java:175)
	at org.tikv.common.region.StoreHealthyChecker.checkTiFlashHealth(StoreHealthyChecker.java:99)
	at org.tikv.common.region.StoreHealthyChecker.checkStoreHealth(StoreHealthyChecker.java:86)
	at org.tikv.common.region.StoreHealthyChecker.run(StoreHealthyChecker.java:154)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
23/05/20 15:31:13 WARN RangeSplitter: Cannot find valid store on TiFlash(engine=tiflash)
```


2. TiSpark success with the client-java build by this pr

### Side effects

<!-- REMOVE the items that are not applicable -->
- Possible performance regression, WHY: **TBD**
- Increased code complexity, WHY: **TBD**
- Breaking backward compatibility, WHY: **TBD**
- NO side effects

### Related changes

<!-- REMOVE the items that are not applicable -->
- Need to cherry-pick to the release branch
- Need to update the documentation
- Need to be included in the release note
- NO related changes
