### PR TITLE
[to #763] Complement v2 codec unit test cases

### DIFF
--- a/src/test/java/org/tikv/common/apiversion/RequestKeyCodecTest.java
+++ b/src/test/java/org/tikv/common/apiversion/RequestKeyCodecTest.java
@@ -181,27 +181,24 @@ public class RequestKeyCodecTest {
     {
       ByteString m_123 = CodecUtils.encode(ByteString.copyFromUtf8("m_123"));
       ByteString m_124 = CodecUtils.encode(ByteString.copyFromUtf8("m_124"));
-      ByteString infiniteEndKey_0 = CodecUtils.encode(v2.infiniteEndKey.concat(ByteString.copyFrom(new byte[] {0})));
+      ByteString infiniteEndKey_0 =
+          CodecUtils.encode(v2.infiniteEndKey.concat(ByteString.copyFrom(new byte[] {0})));
       ByteString t_123 = CodecUtils.encode(ByteString.copyFromUtf8("t_123"));
       ByteString y_123 = CodecUtils.encode(ByteString.copyFromUtf8("y_123"));
 
       ByteString[][] outOfKeyspaceCases = {
-          {ByteString.EMPTY, CodecUtils.encode(v2.keyPrefix)},    // ["", "r000"/"x000")
-          {ByteString.EMPTY, m_123},
-          {m_123, m_124},
-          {m_124, CodecUtils.encode(v2.keyPrefix)},
-          {CodecUtils.encode(v2.infiniteEndKey), ByteString.EMPTY}, // ["r001"/"x001", "")
-          {CodecUtils.encode(v2.infiniteEndKey), infiniteEndKey_0},
-          {infiniteEndKey_0, t_123},
-          {y_123, ByteString.EMPTY}, // "y_123" is bigger than "infiniteEndKey" for both raw & txn.
+        {ByteString.EMPTY, CodecUtils.encode(v2.keyPrefix)}, // ["", "r000"/"x000")
+        {ByteString.EMPTY, m_123},
+        {m_123, m_124},
+        {m_124, CodecUtils.encode(v2.keyPrefix)},
+        {CodecUtils.encode(v2.infiniteEndKey), ByteString.EMPTY}, // ["r001"/"x001", "")
+        {CodecUtils.encode(v2.infiniteEndKey), infiniteEndKey_0},
+        {infiniteEndKey_0, t_123},
+        {y_123, ByteString.EMPTY}, // "y_123" is bigger than "infiniteEndKey" for both raw & txn.
       };
-      
+
       for (ByteString[] testCase : outOfKeyspaceCases) {
-        region =
-            Region.newBuilder()
-                .setStartKey(testCase[0])
-                .setEndKey(testCase[1])
-                .build();
+        region = Region.newBuilder().setStartKey(testCase[0]).setEndKey(testCase[1]).build();
         try {
           decoded = v2.decodeRegion(region);
           fail(String.format("[%s,%s): %s", testCase[0], testCase[1], decoded.toString()));


### PR DESCRIPTION
<!-- Thank you for contributing to TiKV Java Client!

PR Title Format: "[close/to/fix #issue_number] summary" -->

### What problem does this PR solve?

Issue Number: close #763 

Problem Description: **decode EpochNotMatch should ignore invalid region**

### What is changed and how does it work?

Complement v2 codec unit test cases for the scene that the region is out of keyspace.

Ref: #766 

### Code changes

<!-- REMOVE the items that are not applicable -->
- No.

### Check List for Tests

This PR has been tested by at least one of the following methods:
- Unit test

### Side effects

<!-- REMOVE the items that are not applicable -->
- NO side effects

### Related changes

<!-- REMOVE the items that are not applicable -->
- NO related changes
