### PR TITLE
[close #772] Fix flaky integration tests

### DIFF
--- a/.github/config/tikv_rawkv.toml
+++ b/.github/config/tikv_rawkv.toml
@@ -19,3 +19,7 @@ capacity = "128MB"
 [storage]
 reserve-space = "0MB"
 enable-ttl = true
+
+[server]
+addr = "127.0.0.1:20160"
+status-addr = "127.0.0.1:20180"

--- a/.github/config/tikv_rawkv.toml
+++ b/.github/config/tikv_rawkv.toml
@@ -2,7 +2,7 @@
 
 [raftstore]
 # set store capacity, if no set, use disk capacity.
-capacity = "8G"
+capacity = "6G"
 pd-heartbeat-tick-interval = "2s"
 pd-store-heartbeat-tick-interval = "5s"
 split-region-check-tick-interval = "1s"

--- a/.github/config/tikv_rawkv.toml
+++ b/.github/config/tikv_rawkv.toml
@@ -19,7 +19,3 @@ capacity = "128MB"
 [storage]
 reserve-space = "0MB"
 enable-ttl = true
-
-[server]
-addr = "127.0.0.1:20160"
-status-addr = "127.0.0.1:20180"

--- a/.github/config/tikv_rawkv.toml
+++ b/.github/config/tikv_rawkv.toml
@@ -7,12 +7,15 @@ pd-heartbeat-tick-interval = "2s"
 pd-store-heartbeat-tick-interval = "5s"
 split-region-check-tick-interval = "1s"
 
-[storage]
-enable-ttl = true
-
 [rocksdb]
 max-open-files = 10000
 
 [raftdb]
 max-open-files = 10000
 
+[storage.block-cache]
+capacity = "128MB"
+
+[storage]
+reserve-space = "0MB"
+enable-ttl = true

--- a/.github/config/tikv_txnkv.toml
+++ b/.github/config/tikv_txnkv.toml
@@ -18,3 +18,7 @@ capacity = "128MB"
 
 [storage]
 reserve-space = "0MB"
+
+[server]
+addr = "127.0.0.1:30160"
+status-addr = "127.0.0.1:30180"

--- a/.github/config/tikv_txnkv.toml
+++ b/.github/config/tikv_txnkv.toml
@@ -12,3 +12,9 @@ max-open-files = 10000
 
 [raftdb]
 max-open-files = 10000
+
+[storage.block-cache]
+capacity = "128MB"
+
+[storage]
+reserve-space = "0MB"

--- a/.github/config/tikv_txnkv.toml
+++ b/.github/config/tikv_txnkv.toml
@@ -18,7 +18,3 @@ capacity = "128MB"
 
 [storage]
 reserve-space = "0MB"
-
-[server]
-addr = "127.0.0.1:30160"
-status-addr = "127.0.0.1:30180"

--- a/.github/config/tikv_txnkv.toml
+++ b/.github/config/tikv_txnkv.toml
@@ -2,7 +2,7 @@
 
 [raftstore]
 # set store capacity, if no set, use disk capacity.
-capacity = "8G"
+capacity = "6G"
 pd-heartbeat-tick-interval = "2s"
 pd-store-heartbeat-tick-interval = "5s"
 split-region-check-tick-interval = "1s"

--- a/.github/config/tikv_v2.toml
+++ b/.github/config/tikv_v2.toml
@@ -1,0 +1,17 @@
+# TiKV Configuration.
+
+[raftstore]
+pd-heartbeat-tick-interval = "2s"
+pd-store-heartbeat-tick-interval = "5s"
+split-region-check-tick-interval = "1s"
+
+[rocksdb]
+max-open-files = 10000
+
+[raftdb]
+max-open-files = 10000
+
+[storage]
+reserve-space = "0MB"
+api-version = 2
+enable-ttl = true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         run: |
           # Start TiKV in APIV1TTL
           touch tiup-v1ttl.log
-          /home/runner/.tiup/bin/tiup playground ${{ matrix.tikv_version }} --tag rawkv --mode tikv-slim --kv 1 --without-monitor --kv.config /home/runner/work/client-java/client-java/.github/config/tikv_rawkv.toml --pd.config /home/runner/work/client-java/client-java/.github/config/pd.toml --pd.port 2379 2>&1 >> tiup-v1ttl.log &
+          /home/runner/.tiup/bin/tiup playground ${{ matrix.tikv_version }} --host 127.0.0.1 --tag rawkv --mode tikv-slim --kv 1 --without-monitor --kv.port 20160 --kv.config /home/runner/work/client-java/client-java/.github/config/tikv_rawkv.toml --pd.config /home/runner/work/client-java/client-java/.github/config/pd.toml --pd.port 2379 2>&1 >> tiup-v1ttl.log &
           timeout 300 grep -q "PD Endpoints:" <(tail -f tiup-v1ttl.log)
           cat tiup-v1ttl.log
           echo "Wait for bootstrap"
@@ -56,7 +56,7 @@ jobs:
 
           # Start TiKV in APIV1
           touch tiup-v1.log
-          /home/runner/.tiup/bin/tiup playground ${{ matrix.tikv_version }} --tag txnkv --mode tikv-slim --kv 1 --without-monitor --kv.config /home/runner/work/client-java/client-java/.github/config/tikv_txnkv.toml --pd.config /home/runner/work/client-java/client-java/.github/config/pd.toml --pd.port 2381 2>&1 >> tiup-v1.log &
+          /home/runner/.tiup/bin/tiup playground ${{ matrix.tikv_version }} --host 127.0.0.1 --tag txnkv --mode tikv-slim --kv 1 --without-monitor --kv.port 30160 --kv.config /home/runner/work/client-java/client-java/.github/config/tikv_txnkv.toml --pd.config /home/runner/work/client-java/client-java/.github/config/pd.toml --pd.port 2381 2>&1 >> tiup-v1.log &
           timeout 300 grep -q "PD Endpoints:" <(tail -f tiup-v1.log)
           cat tiup-v1.log
           echo "Wait for bootstrap"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         run: |
           # Start TiKV in APIV1TTL
           touch tiup-v1ttl.log
-          /home/runner/.tiup/bin/tiup playground ${{ matrix.tikv_version }} --mode tikv-slim --kv 1 --without-monitor --kv.config /home/runner/work/client-java/client-java/.github/config/tikv_rawkv.toml --pd.config /home/runner/work/client-java/client-java/.github/config/pd.toml --pd.port 2379 2>&1 >> tiup-v1ttl.log &
+          /home/runner/.tiup/bin/tiup playground ${{ matrix.tikv_version }} --tag rawkv --mode tikv-slim --kv 1 --without-monitor --kv.config /home/runner/work/client-java/client-java/.github/config/tikv_rawkv.toml --pd.config /home/runner/work/client-java/client-java/.github/config/pd.toml --pd.port 2379 2>&1 >> tiup-v1ttl.log &
           timeout 300 grep -q "PD Endpoints:" <(tail -f tiup-v1ttl.log)
           cat tiup-v1ttl.log
           echo "Wait for bootstrap"
@@ -55,7 +55,7 @@ jobs:
 
           # Start TiKV in APIV1
           touch tiup-v1.log
-          /home/runner/.tiup/bin/tiup playground ${{ matrix.tikv_version }} --mode tikv-slim --kv 1 --without-monitor --kv.config /home/runner/work/client-java/client-java/.github/config/tikv_txnkv.toml --pd.config /home/runner/work/client-java/client-java/.github/config/pd.toml --pd.port 2381 2>&1 >> tiup-v1.log &
+          /home/runner/.tiup/bin/tiup playground ${{ matrix.tikv_version }} --tag txnkv --mode tikv-slim --kv 1 --without-monitor --kv.config /home/runner/work/client-java/client-java/.github/config/tikv_txnkv.toml --pd.config /home/runner/work/client-java/client-java/.github/config/pd.toml --pd.port 2381 2>&1 >> tiup-v1.log &
           timeout 300 grep -q "PD Endpoints:" <(tail -f tiup-v1.log)
           cat tiup-v1.log
           echo "Wait for bootstrap"
@@ -67,6 +67,14 @@ jobs:
 
       - name: Run Integration Test
         run: mvn clean test
+      - name: Print TiKV logs
+        if: failure()
+        run: |
+          echo "RawKV TiKV logs"
+          cat /home/runner/.tiup/data/rawkv/tikv-0/tikv.log
+          
+          echo "TxnKV TiKV logs"
+          cat /home/runner/.tiup/data/txnkv/tikv-0/tikv.log
       - name: Upload coverage
         uses: codecov/codecov-action@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,19 +42,19 @@ jobs:
       - name: Install TiUP
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://tiup-mirrors.pingcap.com/install.sh | sh
-          /home/runner/.tiup/bin/tiup install pd:${{ matrix.tikv_version }} tikv:${{ matrix.tikv_version }}
+          /home/runner/.tiup/bin/tiup install playground pd:${{ matrix.tikv_version }} tikv:${{ matrix.tikv_version }}
       - name: Start TiUP Playground
         run: |
           # Start TiKV in APIV1TTL
           touch tiup-v1ttl.log
           /home/runner/.tiup/bin/tiup playground ${{ matrix.tikv_version }} --mode tikv-slim --kv 1 --without-monitor --kv.config /home/runner/work/client-java/client-java/.github/config/tikv_rawkv.toml --pd.config /home/runner/work/client-java/client-java/.github/config/pd.toml --pd.port 2379 2>&1 >> tiup-v1ttl.log &
-          grep -q "PD Endpoints:" <(tail -f tiup-v1ttl.log)
+          timeout 300 grep -q "PD Endpoints:" <(tail -f tiup-v1ttl.log)
           cat tiup-v1ttl.log
 
           # Start TiKV in APIV1
           touch tiup-v1.log
           /home/runner/.tiup/bin/tiup playground ${{ matrix.tikv_version }} --mode tikv-slim --kv 1 --without-monitor --kv.config /home/runner/work/client-java/client-java/.github/config/tikv_txnkv.toml --pd.config /home/runner/work/client-java/client-java/.github/config/pd.toml --pd.port 2381 2>&1 >> tiup-v1.log &
-          grep -q "PD Endpoints:" <(tail -f tiup-v1.log)
+          timeout 300 grep -q "PD Endpoints:" <(tail -f tiup-v1.log)
           cat tiup-v1.log
 
           # Get PD address

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tikv_version: [v6.5.3]
+        tikv_version: [v5.0.4]
+      fail-fast: false
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tikv_version: [v5.0.4]
+        tikv_version: [v5.0.6, v5.3.4, v5.4.3]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
@@ -52,7 +52,7 @@ jobs:
           timeout 300 grep -q "PD Endpoints:" <(tail -f tiup-v1ttl.log)
           cat tiup-v1ttl.log
           echo "Wait for bootstrap"
-          sleep 15s
+          sleep 10s
 
           # Start TiKV in APIV1
           touch tiup-v1.log
@@ -60,7 +60,7 @@ jobs:
           timeout 300 grep -q "PD Endpoints:" <(tail -f tiup-v1.log)
           cat tiup-v1.log
           echo "Wait for bootstrap"
-          sleep 15s
+          sleep 10s
 
           # Get PD address
           echo "RAWKV_PD_ADDRESSES=127.0.0.1:2379" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,15 +44,12 @@ jobs:
       - name: Start TiUP Playground
         run: |
           # Start TiKV in APIV1TTL
-          /home/runner/.tiup/bin/tiup playground ${{ matrix.tikv_version }} --mode tikv-slim --kv 1 --without-monitor --kv.config /home/runner/work/client-java/client-java/.github/config/tikv_rawkv.toml --pd.config /home/runner/work/client-java/client-java/.github/config/pd.toml --pd.port 2379 2>&1 &
-
-          # The first run of `tiup` has to download all components so it'll take longer.
-          sleep 1m 30s
+          /home/runner/.tiup/bin/tiup playground ${{ matrix.tikv_version }} --mode tikv-slim --kv 1 --without-monitor --kv.config /home/runner/work/client-java/client-java/.github/config/tikv_rawkv.toml --pd.config /home/runner/work/client-java/client-java/.github/config/pd.toml --pd.port 2379 2>&1 > tiup-v1ttl.log &
+          grep -q "PD Endpoints:" <(tail -f tiup-v1ttl.log)
 
           # Start TiKV in APIV1
-          /home/runner/.tiup/bin/tiup playground ${{ matrix.tikv_version }} --mode tikv-slim --kv 1 --without-monitor --kv.config /home/runner/work/client-java/client-java/.github/config/tikv_txnkv.toml --pd.config /home/runner/work/client-java/client-java/.github/config/pd.toml --pd.port 2381 2>&1 &
-
-          sleep 30s
+          /home/runner/.tiup/bin/tiup playground ${{ matrix.tikv_version }} --mode tikv-slim --kv 1 --without-monitor --kv.config /home/runner/work/client-java/client-java/.github/config/tikv_txnkv.toml --pd.config /home/runner/work/client-java/client-java/.github/config/pd.toml --pd.port 2381 2>&1 > tiup-v1.log &
+          grep -q "PD Endpoints:" <(tail -f tiup-v1.log)
 
           # Get PD address
           echo "RAWKV_PD_ADDRESSES=127.0.0.1:2379" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,12 +50,16 @@ jobs:
           /home/runner/.tiup/bin/tiup playground ${{ matrix.tikv_version }} --mode tikv-slim --kv 1 --without-monitor --kv.config /home/runner/work/client-java/client-java/.github/config/tikv_rawkv.toml --pd.config /home/runner/work/client-java/client-java/.github/config/pd.toml --pd.port 2379 2>&1 >> tiup-v1ttl.log &
           timeout 300 grep -q "PD Endpoints:" <(tail -f tiup-v1ttl.log)
           cat tiup-v1ttl.log
+          echo "Wait for bootstrap"
+          sleep 15s
 
           # Start TiKV in APIV1
           touch tiup-v1.log
           /home/runner/.tiup/bin/tiup playground ${{ matrix.tikv_version }} --mode tikv-slim --kv 1 --without-monitor --kv.config /home/runner/work/client-java/client-java/.github/config/tikv_txnkv.toml --pd.config /home/runner/work/client-java/client-java/.github/config/pd.toml --pd.port 2381 2>&1 >> tiup-v1.log &
           timeout 300 grep -q "PD Endpoints:" <(tail -f tiup-v1.log)
           cat tiup-v1.log
+          echo "Wait for bootstrap"
+          sleep 15s
 
           # Get PD address
           echo "RAWKV_PD_ADDRESSES=127.0.0.1:2379" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tikv_version: [nightly, v5.0.4, v5.3.0, v5.4.0]
+        tikv_version: [v6.5.3]
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,16 +40,22 @@ jobs:
           java-version: '8.0'
           distribution: 'adopt'
       - name: Install TiUP
-        run: curl --proto '=https' --tlsv1.2 -sSf https://tiup-mirrors.pingcap.com/install.sh | sh
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://tiup-mirrors.pingcap.com/install.sh | sh
+          /home/runner/.tiup/bin/tiup install pd:${{ matrix.tikv_version }} tikv:${{ matrix.tikv_version }}
       - name: Start TiUP Playground
         run: |
           # Start TiKV in APIV1TTL
-          /home/runner/.tiup/bin/tiup playground ${{ matrix.tikv_version }} --mode tikv-slim --kv 1 --without-monitor --kv.config /home/runner/work/client-java/client-java/.github/config/tikv_rawkv.toml --pd.config /home/runner/work/client-java/client-java/.github/config/pd.toml --pd.port 2379 2>&1 > tiup-v1ttl.log &
+          touch tiup-v1ttl.log
+          /home/runner/.tiup/bin/tiup playground ${{ matrix.tikv_version }} --mode tikv-slim --kv 1 --without-monitor --kv.config /home/runner/work/client-java/client-java/.github/config/tikv_rawkv.toml --pd.config /home/runner/work/client-java/client-java/.github/config/pd.toml --pd.port 2379 2>&1 >> tiup-v1ttl.log &
           grep -q "PD Endpoints:" <(tail -f tiup-v1ttl.log)
+          cat tiup-v1ttl.log
 
           # Start TiKV in APIV1
-          /home/runner/.tiup/bin/tiup playground ${{ matrix.tikv_version }} --mode tikv-slim --kv 1 --without-monitor --kv.config /home/runner/work/client-java/client-java/.github/config/tikv_txnkv.toml --pd.config /home/runner/work/client-java/client-java/.github/config/pd.toml --pd.port 2381 2>&1 > tiup-v1.log &
+          touch tiup-v1.log
+          /home/runner/.tiup/bin/tiup playground ${{ matrix.tikv_version }} --mode tikv-slim --kv 1 --without-monitor --kv.config /home/runner/work/client-java/client-java/.github/config/tikv_txnkv.toml --pd.config /home/runner/work/client-java/client-java/.github/config/pd.toml --pd.port 2381 2>&1 >> tiup-v1.log &
           grep -q "PD Endpoints:" <(tail -f tiup-v1.log)
+          cat tiup-v1.log
 
           # Get PD address
           echo "RAWKV_PD_ADDRESSES=127.0.0.1:2379" >> $GITHUB_ENV

--- a/.github/workflows/ci_v2.yml
+++ b/.github/workflows/ci_v2.yml
@@ -1,0 +1,52 @@
+name: CI (APIv2)
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  integration-test:
+    name: Integration Test - ${{ matrix.tikv_version }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        tikv_version: [v6.5.3]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: actions/setup-java@v2
+        with:
+          java-version: '8.0'
+          distribution: 'adopt'
+      - name: Install TiUP
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://tiup-mirrors.pingcap.com/install.sh | sh
+          /home/runner/.tiup/bin/tiup install playground pd:${{ matrix.tikv_version }} tikv:${{ matrix.tikv_version }}
+      - name: Start TiUP Playground
+        run: |
+          # Start TiKV in APIV2
+          touch tiup.log
+          /home/runner/.tiup/bin/tiup playground ${{ matrix.tikv_version }} --tag kv --mode tikv-slim --kv 1 --without-monitor --kv.config /home/runner/work/client-java/client-java/.github/config/tikv_v2.toml --pd.config /home/runner/work/client-java/client-java/.github/config/pd.toml --pd.port 2379 2>&1 >> tiup.log &
+          timeout 300 grep -q "PD Endpoints:" <(tail -f tiup.log)
+          cat tiup.log
+
+          # Get PD address
+          echo "RAWKV_PD_ADDRESSES=127.0.0.1:2379" >> $GITHUB_ENV
+          echo "TXNKV_PD_ADDRESSES=127.0.0.1:2379" >> $GITHUB_ENV
+
+      - name: Run Integration Test
+        run: mvn clean test
+      - name: Print TiKV logs
+        if: failure()
+        run: |
+          echo "TiKV logs"
+          cat /home/runner/.tiup/data/kv/tikv-0/tikv.log
+      - name: Upload coverage
+        uses: codecov/codecov-action@v2
+        with:
+          files: ${{ github.workspace }}/target/site/jacoco/jacoco.xml
+          fail_ci_if_error: true
+          verbose: true

--- a/.github/workflows/ci_v2.yml
+++ b/.github/workflows/ci_v2.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tikv_version: [v6.5.3]
+        tikv_version: [v6.5.3, v7.1.1, nightly]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
<!-- Thank you for contributing to TiKV Java Client!

PR Title Format: "[close/to/fix #issue_number] summary" -->

### What problem does this PR solve?

Issue Number: close #772 

Problem Description: **Integration tests in CI are flaky**

### What is changed and how does it work?

The reason of failure of integration tests in CI seems to be TiKV OOM.

We can see PD response with errors that "cluster is not bootstrapped" (see "Run Integration Test" in https://github.com/tikv/client-java/actions/runs/6390085322/job/17342615588?pr=770)

```
11949 [main] WARN  org.tikv.common.util.ConcreteBackOffer  - BackOffer.maxSleep 5000ms is exceeded, errors:
11949 [main] WARN  org.tikv.common.util.ConcreteBackOffer  - 
11.org.tikv.common.exception.GrpcException: 
ErrorType: PD_ERROR
Error: type: NOT_BOOTSTRAPPED
message: "cluster is not bootstrapped"

12.org.tikv.common.exception.GrpcException: 
ErrorType: PD_ERROR
Error: type: NOT_BOOTSTRAPPED
message: "cluster is not bootstrapped"

13.org.tikv.common.exception.GrpcException: 
ErrorType: PD_ERROR
Error: type: NOT_BOOTSTRAPPED
message: "cluster is not bootstrapped"
```

After print TiKV logs after failure, there is no more logs after TiKV print the "using config" (see "Print TiKV logs" in https://github.com/tikv/client-java/actions/runs/6390085322/job/17342615588?pr=770). It was very likely to be OOM killed.

Containers in Github action runner has only `7GB` memory (see https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners). I think it's not enough for 2 PD and 2 TiKV, especially for newer versions.

To address the issue, this PR setup only one cluster in CI, and enable APIv2 to accept both RawKV & TxnKV test cases.

At the same time, keep 2 clusters for older versions, and cover the scenarios of `APIv1` & `APIv1 TTL`.

#### Changes:

- Add a new workflow for TiKV versions `v6.5.3`, `v7.1.1` & `nightly`, which setup only one cluster and enable `APIv2`.
- Optimize sleeping after cluster startup by waiting for the message "PD Endpoints" (see https://github.com/pingcap/tiup/blob/v1.13.1/components/playground/playground.go#L1108. p.s. Maybe we should add a feature to make this message stable)
- Reduce `raftstore.capacity` as there is only `14GB` disk in Github action runner.
- Limit `storage.block-cache.capacity` to make less chances of OOM killed.
- Set TiKV port explicitly by passing `--kv.port xxx` argument to TiUP. Otherwise TiKV of txnkv will complain about the port is occupied (`[2023/10/03 09:02:28.144 +00:00] [FATAL] [server.rs:1165] ["127.0.0.1_20160 already in use, maybe another instance is binding with this address."]`, see https://github.com/tikv/client-java/actions/runs/6390868184/job/17345000675?pr=770). It may be an issue of TiUP as it should get a free port, but just work around this issue in this PR).
- Print TiKV logs on failure for trouble shooting.

### Code changes

<!-- REMOVE the items that are not applicable -->
- No code

### Check List for Tests

This PR has been tested by at least one of the following methods:
- Integration test

### Side effects

<!-- REMOVE the items that are not applicable -->
- NO side effects

### Related changes

<!-- REMOVE the items that are not applicable -->
- Need to cherry-pick to the release branch
