### PR TITLE
[close #782] bump grpc to 1.60.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,14 +57,14 @@
         <protobuf.version>3.18.0</protobuf.version>
         <log4j.version>1.2.17</log4j.version>
         <slf4j.version>1.7.16</slf4j.version>
-        <grpc.version>1.48.0</grpc.version>
+        <grpc.version>1.60.0</grpc.version>
         <netty.tcnative.version>2.0.34.Final</netty.tcnative.version>
         <gson.version>2.8.9</gson.version>
         <powermock.version>1.6.6</powermock.version>
         <jackson-annotations.version>2.13.2</jackson-annotations.version>
         <jackson.version>2.13.4.2</jackson.version>
         <trove4j.version>3.0.1</trove4j.version>
-        <jetcd.version>0.4.1</jetcd.version>
+        <jetcd.version>0.7.7</jetcd.version>
         <joda-time.version>2.9.9</joda-time.version>
         <joda-convert.version>1.9.2</joda-convert.version>
         <proto.folder>${basedir}/proto</proto.folder>
@@ -188,20 +188,6 @@
         <dependency>
             <groupId>io.etcd</groupId>
             <artifactId>jetcd-core</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>io.etcd</groupId>
-                    <artifactId>jetcd-resolver</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.etcd</groupId>
-                    <artifactId>jetcd-common</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.grpc</groupId>
-                    <artifactId>grpc-grpclb</artifactId>
-                </exclusion>
-            </exclusions>
             <version>${jetcd.version}</version>
         </dependency>
         <dependency>

--- a/src/main/java/org/tikv/common/PDClient.java
+++ b/src/main/java/org/tikv/common/PDClient.java
@@ -108,7 +108,6 @@ import org.tikv.kvproto.Pdpb.UpdateServiceGCSafePointRequest;
 
 public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDFutureStub>
     implements ReadOnlyPDClient {
-
   private static final String TIFLASH_TABLE_SYNC_PROGRESS_PATH = "/tiflash/table/sync";
   private static final long MIN_TRY_UPDATE_DURATION = 50;
   private static final int PAUSE_CHECKER_TIMEOUT = 300; // in seconds
@@ -830,7 +829,6 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDFutureStub>
   }
 
   static class PDClientWrapper {
-
     private final String leaderInfo;
     private final PDBlockingStub blockingStub;
     private final PDFutureStub asyncStub;

--- a/src/main/java/org/tikv/common/region/AbstractRegionStoreClient.java
+++ b/src/main/java/org/tikv/common/region/AbstractRegionStoreClient.java
@@ -209,8 +209,9 @@ public abstract class AbstractRegionStoreClient
     if (store.getProxyStore() != null) {
       Metadata header = new Metadata();
       header.put(TiConfiguration.FORWARD_META_DATA_KEY, store.getStore().getAddress());
-      blockingStub = MetadataUtils.attachHeaders(blockingStub, header);
-      asyncStub = MetadataUtils.attachHeaders(asyncStub, header);
+      blockingStub =
+          blockingStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(header));
+      asyncStub = asyncStub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(header));
     }
   }
 
@@ -371,7 +372,8 @@ public abstract class AbstractRegionStoreClient
                 .setKey(codec.encodeKey(key))
                 .build();
         ListenableFuture<Kvrpcpb.RawGetResponse> task =
-            MetadataUtils.attachHeaders(stub, header).rawGet(rawGetRequest);
+            stub.withInterceptors(MetadataUtils.newAttachHeadersInterceptor(header))
+                .rawGet(rawGetRequest);
         responses.add(new ForwardCheckTask(task, peerStore.getStore()));
       } catch (Exception e) {
         logger.warn(

--- a/src/main/java/org/tikv/common/region/RegionStoreClient.java
+++ b/src/main/java/org/tikv/common/region/RegionStoreClient.java
@@ -127,7 +127,6 @@ import org.tikv.txn.exception.LockException;
 
 /** Note that RegionStoreClient itself is not thread-safe */
 public class RegionStoreClient extends AbstractRegionStoreClient {
-
   private static final Logger logger = LoggerFactory.getLogger(RegionStoreClient.class);
   @VisibleForTesting public final AbstractLockResolverClient lockResolverClient;
   private final TiStoreType storeType;

--- a/src/main/java/org/tikv/common/region/RegionStoreClient.java
+++ b/src/main/java/org/tikv/common/region/RegionStoreClient.java
@@ -127,6 +127,7 @@ import org.tikv.txn.exception.LockException;
 
 /** Note that RegionStoreClient itself is not thread-safe */
 public class RegionStoreClient extends AbstractRegionStoreClient {
+
   private static final Logger logger = LoggerFactory.getLogger(RegionStoreClient.class);
   @VisibleForTesting public final AbstractLockResolverClient lockResolverClient;
   private final TiStoreType storeType;
@@ -1395,8 +1396,12 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
             channelFactory.getChannel(addressStr, regionManager.getPDClient().getHostMapping());
         Metadata header = new Metadata();
         header.put(TiConfiguration.FORWARD_META_DATA_KEY, store.getStore().getAddress());
-        blockingStub = MetadataUtils.attachHeaders(TikvGrpc.newBlockingStub(channel), header);
-        asyncStub = MetadataUtils.attachHeaders(TikvGrpc.newFutureStub(channel), header);
+        blockingStub =
+            TikvGrpc.newBlockingStub(channel)
+                .withInterceptors(MetadataUtils.newAttachHeadersInterceptor(header));
+        asyncStub =
+            TikvGrpc.newFutureStub(channel)
+                .withInterceptors(MetadataUtils.newAttachHeadersInterceptor(header));
       } else {
         channel = channelFactory.getChannel(addressStr, pdClient.getHostMapping());
         blockingStub = TikvGrpc.newBlockingStub(channel);


### PR DESCRIPTION
### What problem does this PR solve?
This pull request bumps the gRPC version to 1.60.0 as the same deps of jetcd 0.7.7. Might related to https://github.com/grpc/grpc-java/issues/9340

I can reproduce the memory leak while using gRPC 1.48.0 as described in issue #782. When I bump the gRPC to 1.60.0 the error logs disappear even I run the test 100 times.

Issue Number: close #782 


### What has changed and how does it work?

Bump the gRPC version to 1.60.0.

### Code changes

<!-- REMOVE the items that are not applicable -->
- Has exported function/method change
- Has exported variable/fields change
- Has methods of interface change
- Has persistent data change
- No code

### Check List for Tests

This PR has been tested by at least one of the following methods:
- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

### Side effects

<!-- REMOVE the items that are not applicable -->
- Possible performance regression, WHY: **TBD**
- Increased code complexity, WHY: **TBD**
- Breaking backward compatibility, WHY: **TBD**
- NO side effects

### Related changes

<!-- REMOVE the items that are not applicable -->
- Need to cherry-pick to the release branch
