### PR TITLE
[to #788] Reduce the number of ObjectMapper creations to improve performance

### DIFF
--- a/src/main/java/org/tikv/common/PDClient.java
+++ b/src/main/java/org/tikv/common/PDClient.java
@@ -113,6 +113,7 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDFutureStub>
   private static final int PAUSE_CHECKER_TIMEOUT = 300; // in seconds
   private static final int KEEP_CHECKER_PAUSE_PERIOD = PAUSE_CHECKER_TIMEOUT / 5; // in seconds
   private static final Logger logger = LoggerFactory.getLogger(PDClient.class);
+  private static final ObjectMapper mapper = new ObjectMapper();
 
   private final RequestKeyCodec codec;
   private RequestHeader header;
@@ -226,7 +227,6 @@ public class PDClient extends AbstractGRPCClient<PDBlockingStub, PDFutureStub>
     URI url = pdAddrs.get(0);
     String api = url.toString() + "/pd/api/v1/checker/" + checker.apiName();
     try {
-      ObjectMapper mapper = new ObjectMapper();
       HashMap<String, Boolean> status =
           mapper.readValue(new URL(api), new TypeReference<HashMap<String, Boolean>>() {});
       return status.get("paused");

--- a/src/main/java/org/tikv/common/TiDBJDBCClient.java
+++ b/src/main/java/org/tikv/common/TiDBJDBCClient.java
@@ -41,6 +41,7 @@ public class TiDBJDBCClient implements AutoCloseable {
   private static final int DELAY_CLEAN_TABLE_LOCK_DEFAULT = 0;
   private static final String TIDB_ROW_FORMAT_VERSION_SQL = "select @@tidb_row_format_version";
   private static final int TIDB_ROW_FORMAT_VERSION_DEFAULT = 1;
+  private static final ObjectMapper objectMapper = new ObjectMapper();
   private final Logger logger = LoggerFactory.getLogger(getClass().getName());
   private final Connection connection;
 
@@ -120,7 +121,6 @@ public class TiDBJDBCClient implements AutoCloseable {
 
   private Map<String, Object> readConfMapFromTiDB() throws SQLException, IOException {
     String configJSON = (String) queryTiDBViaJDBC(SELECT_TIDB_CONFIG_SQL).get(0).get(0);
-    ObjectMapper objectMapper = new ObjectMapper();
     TypeReference<HashMap<String, Object>> typeRef =
         new TypeReference<HashMap<String, Object>>() {};
     return objectMapper.readValue(configJSON, typeRef);

--- a/src/main/java/org/tikv/common/catalog/CatalogTransaction.java
+++ b/src/main/java/org/tikv/common/catalog/CatalogTransaction.java
@@ -40,6 +40,7 @@ import org.tikv.common.util.Pair;
 
 public class CatalogTransaction {
   protected static final Logger logger = LoggerFactory.getLogger(CatalogTransaction.class);
+  private static final ObjectMapper mapper = new ObjectMapper();
   private final Snapshot snapshot;
 
   CatalogTransaction(Snapshot snapshot) {
@@ -51,7 +52,6 @@ public class CatalogTransaction {
     Objects.requireNonNull(cls, "cls is null");
 
     logger.debug(String.format("Parse Json %s : %s", cls.getSimpleName(), json.toStringUtf8()));
-    ObjectMapper mapper = new ObjectMapper();
     try {
       return mapper.readValue(json.toStringUtf8(), cls);
     } catch (JsonParseException | JsonMappingException e) {


### PR DESCRIPTION
<!-- Thank you for contributing to TiKV Java Client!

PR Title Format: "[close/to/fix #issue_number] summary" -->

### What problem does this PR solve?

Problem Description: ObjectMapper is actually a thread-safe object that can be reused to improve performance. Creating an ObjectMapper object is not fast.

### What is changed and how does it work?

Code Refactor.

### Code changes

<!-- REMOVE the items that are not applicable -->
- Has exported function/method change
- Has exported variable/fields change
- Has methods of interface change
- Has persistent data change
- No code

### Check List for Tests

This PR has been tested by at least one of the following methods:
- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

### Side effects

<!-- REMOVE the items that are not applicable -->
- Possible performance regression, WHY: **TBD**
- Increased code complexity, WHY: **TBD**
- Breaking backward compatibility, WHY: **TBD**
- NO side effects

### Related changes

<!-- REMOVE the items that are not applicable -->
- Need to cherry-pick to the release branch
- Need to update the documentation
- Need to be included in the release note
- NO related changes
