### PR TITLE
txn: fix scan missing endKey in V2 API

### DIFF
--- a/src/main/java/org/tikv/common/operation/iterator/ConcreteScanIterator.java
+++ b/src/main/java/org/tikv/common/operation/iterator/ConcreteScanIterator.java
@@ -76,7 +76,7 @@ public class ConcreteScanIterator extends ScanIterator {
     try (RegionStoreClient client = builder.build(startKey)) {
       client.setTimeout(conf.getScanTimeout());
       BackOffer backOffer = ConcreteBackOffer.newScannerNextMaxBackOff();
-      currentCache = client.scan(backOffer, startKey, version);
+      currentCache = client.scan(backOffer, startKey, rangeEndKey, version, keyOnly);
       // If we get region before scan, we will use region from cache which
       // may have wrong end key. This may miss some regions that split from old region.
       // Client will get the newest region during scan. So we need to
@@ -115,7 +115,8 @@ public class ConcreteScanIterator extends ScanIterator {
     // for last batch to be processed, we have to check if
     return !processingLastBatch
         || current == null
-        || (hasEndKey && Key.toRawKey(current.getKey()).compareTo(endKey) < 0);
+        || !hasEndKey
+        || (Key.toRawKey(current.getKey()).compareTo(endKey) < 0);
   }
 
   @Override

--- a/src/main/java/org/tikv/common/operation/iterator/ScanIterator.java
+++ b/src/main/java/org/tikv/common/operation/iterator/ScanIterator.java
@@ -35,6 +35,7 @@ public abstract class ScanIterator implements Iterator<Kvrpcpb.KvPair> {
   protected final RegionStoreClientBuilder builder;
   protected List<Kvrpcpb.KvPair> currentCache;
   protected ByteString startKey;
+  protected ByteString rangeEndKey;
   protected int index = -1;
   protected int limit;
   protected boolean keyOnly;
@@ -52,7 +53,8 @@ public abstract class ScanIterator implements Iterator<Kvrpcpb.KvPair> {
       int limit,
       boolean keyOnly) {
     this.startKey = requireNonNull(startKey, "start key is null");
-    this.endKey = Key.toRawKey(requireNonNull(endKey, "end key is null"));
+    this.rangeEndKey = requireNonNull(endKey, "end key is null");
+    this.endKey = Key.toRawKey(this.rangeEndKey);
     this.hasEndKey = !endKey.isEmpty();
     this.limit = limit;
     this.keyOnly = keyOnly;
@@ -106,9 +108,11 @@ public abstract class ScanIterator implements Iterator<Kvrpcpb.KvPair> {
       }
       // notify last batch if lastKey is greater than or equal to endKey
       // if startKey is empty, it indicates +∞
-      if (hasEndKey && lastKey.compareTo(endKey) >= 0 || startKey.isEmpty()) {
+      if (hasEndKey && lastKey.compareTo(endKey) >= 0) {
         processingLastBatch = true;
         startKey = null;
+      } else if (startKey.isEmpty()) {
+        processingLastBatch = true;
       }
     } catch (Exception e) {
       throw new TiClientInternalException("Error scanning data from region.", e);

--- a/src/main/java/org/tikv/common/region/RegionStoreClient.java
+++ b/src/main/java/org/tikv/common/region/RegionStoreClient.java
@@ -337,15 +337,23 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
 
   public List<KvPair> scan(
       BackOffer backOffer, ByteString startKey, long version, boolean keyOnly) {
+    return scan(backOffer, startKey, ByteString.EMPTY, version, keyOnly);
+  }
+
+  public List<KvPair> scan(
+      BackOffer backOffer, ByteString startKey, ByteString endKey, long version, boolean keyOnly) {
     boolean forWrite = false;
     while (true) {
+      Pair<ByteString, ByteString> range = codec.encodeRange(startKey, endKey);
+
       Supplier<ScanRequest> request =
           () ->
               ScanRequest.newBuilder()
                   .setContext(
                       makeContext(
                           getResolvedLocks(version), this.storeType, backOffer.getSlowLog()))
-                  .setStartKey(codec.encodeKey(startKey))
+                  .setStartKey(range.first)
+                  .setEndKey(range.second)
                   .setVersion(version)
                   .setKeyOnly(keyOnly)
                   .setLimit(getConf().getScanBatchSize())
@@ -367,7 +375,7 @@ public class RegionStoreClient extends AbstractRegionStoreClient {
       region = regionManager.getRegionByKey(startKey, backOffer);
 
       if (handleScanResponse(backOffer, resp, version, forWrite)) {
-        return resp.getPairsList();
+        return codec.decodeKvPairs(resp.getPairsList());
       }
     }
   }


### PR DESCRIPTION
- Add scan(backOffer, startKey, endKey, version, keyOnly) overload
- Use codec.encodeRange() to set both startKey and endKey
- Decode response KvPairs via codec.decodeKvPairs()
- Pass rangeEndKey through ScanIterator

<!-- Thank you for contributing to TiKV Java Client!

PR Title Format: "[close/to/fix #issue_number] summary" -->

### What problem does this PR solve?

Issue Number: close #660 

Problem Description:  In V2 API mode, RegionStoreClient.scan() only sets startKey in the Scan request without encoding or passing endKey, causing TiKV to receive an incomplete scan range and return InvalidReqRange errors. Additionally, the response KvPairs are not decoded (V2 key prefix not stripped), and the ScanIterator/ConcreteScanIterator have incorrect logic when endKey is empty or startKey reaches +∞, causing premature iteration termination.

### What is changed and how does it work?
- Add scan(backOffer, startKey, endKey, version, keyOnly) overload in RegionStoreClient: uses codec.encodeRange() to encode both startKey and endKey together (V2 adds key prefix x\0\0\0; empty endKey is encoded as x\0\0\1 representing the keyspace upper bound). The old 4-param scan() delegates to the new 5-param version with endKey=EMPTY.
- Decode response KvPairs via codec.decodeKvPairs(): strips the V2 key prefix from returned pairs so callers receive keys in user space.
- Pass rangeEndKey through ScanIterator/ConcreteScanIterator: fixes hasNext() logic — when there is no endKey (scan to +∞), !hasEndKey is added as a condition instead of the previous (hasEndKey && compareTo < 0) which short-circuited to false. Fixes cacheLoadFails() — splits the hasEndKey and startKey.isEmpty() conditions into separate if-else branches so that reaching +∞ only marks processingLastBatch without clearing startKey to null.


### Code changes

- Has exported function/method change: RegionStoreClient.scan() adds new overload with endKey parameter
- Has methods of interface change: ScanIterator constructor now accepts and propagates rangeEndKey

### Check List for Tests

This PR has been tested by at least one of the following methods:
- Manual test: verified against TiKV cluste with V2 API
  -  scan("a", "z", startTs) — range scan with both start and end
  -  scan("a", startTs) — scan without endKey (scan to +∞)
  -  scan(EMPTY, EMPTY, startTs) — full table scan
  -  RegionStoreClient.scan(backOffer, startKey, EMPTY, startTs, false) — direct client scan without endKey
  -  All combinations return correct results without InvalidReqRange errors

### Side effects

- NO side effects: the old 4-param scan() method signature is preserved and delegates to the new 5-param version with endKey=EMPTY

### Related changes
- NO related changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Scan operations now support explicit key ranges, allowing more precise reads over a defined start and end key.
* **Bug Fixes**
  * Improved scan continuation logic so scans stop and resume more reliably at range boundaries.
  * Fixed result handling to return decoded key-value data consistently after successful scans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->